### PR TITLE
Fix bug for env var assignment

### DIFF
--- a/src/modules/exec.ts
+++ b/src/modules/exec.ts
@@ -83,11 +83,14 @@ export async function runExecSpec(
         cwd: cwd,
     };
 
-    const args = execSpec.args && execSpec.args.length > 0 ? execSpec.args : programSpec.args;
+    let programArgs = programSpec.args ? programSpec.args : [];
+    if (execSpec.args !== undefined && execSpec.args.length > 0) {
+        programArgs = execSpec.args;
+    }
 
     try {
         const command = programSpec.executable.includes('/') ? resolve(cwd, programSpec.executable) : programSpec.executable;
-        await awaitSpawn(command, args, spawnOptions);
+        await awaitSpawn(command, programArgs, spawnOptions);
     } catch (error) {
         console.error(`There was an error during exec:\n${error}`);
     }

--- a/src/modules/exec.ts
+++ b/src/modules/exec.ts
@@ -84,7 +84,7 @@ export async function runExecSpec(
     };
 
     let programArgs = programSpec.args ? programSpec.args : [];
-    if (execSpec.args !== undefined && execSpec.args.length > 0) {
+    if (execSpec.args && execSpec.args.length > 0) {
         programArgs = execSpec.args;
     }
 

--- a/test/system-test/exec.stest.ts
+++ b/test/system-test/exec.stest.ts
@@ -14,17 +14,24 @@
 
 import { expect } from 'chai';
 import { spawn, spawnSync } from 'child_process';
+import { copySync } from 'fs-extra';
+import { homedir } from 'node:os';
 import { join } from 'path';
+import { cwd } from 'process';
 import YAML from 'yaml';
 
 const VELOCITAS_PROCESS = join('..', '..', process.env['VELOCITAS_PROCESS'] ? process.env['VELOCITAS_PROCESS'] : 'velocitas');
+const TEST_ROOT = cwd();
+const VELOCITAS_HOME = `${homedir()}/.velocitas`;
 
 describe('CLI command', () => {
     describe('exec', () => {
-        before(() => {
-            process.chdir('./testbench/test-exec');
+        beforeEach(() => {
+            process.chdir(`${TEST_ROOT}/testbench/test-exec`);
+            copySync('./packages', `${VELOCITAS_HOME}/packages`);
             spawnSync(VELOCITAS_PROCESS, ['init']);
         });
+
         it('should be able to exec all exposed program specs of runtime-local', async () => {
             const packageOutput = spawnSync(VELOCITAS_PROCESS, ['package', 'devenv-runtime-local'], { encoding: 'utf-8' });
             const parsedPackageOutput = YAML.parse(packageOutput.stdout.toString());
@@ -38,6 +45,14 @@ describe('CLI command', () => {
                 continue;
             }
             expect(spawnSuccesful).to.be.true;
+        });
+
+        it('should pass environment variables to the spawned process', async () => {
+            const result = spawnSync(VELOCITAS_PROCESS, ['exec', 'test-component', 'echo-env'], { encoding: 'utf-8' });
+
+            expect(result.stdout).to.contain('VELOCITAS_WORKSPACE_DIR=');
+            expect(result.stdout).to.contain('VELOCITAS_CACHE_DATA=');
+            expect(result.stdout).to.contain('VELOCITAS_CACHE_DIR=');
         });
     });
 });

--- a/test/system-test/exec.stest.ts
+++ b/test/system-test/exec.stest.ts
@@ -54,6 +54,12 @@ describe('CLI command', () => {
             expect(result.stdout).to.contain('VELOCITAS_CACHE_DATA=');
             expect(result.stdout).to.contain('VELOCITAS_CACHE_DIR=');
         });
+
+        it('should be able to run executables that are on the path', () => {
+            const result = spawnSync(VELOCITAS_PROCESS, ['exec', 'test-component', 'executable-on-path'], { encoding: 'utf-8' });
+
+            expect(result.stdout).to.be.equal('Hello World!\n');
+        });
     });
 });
 

--- a/testbench/test-exec/.velocitas.json
+++ b/testbench/test-exec/.velocitas.json
@@ -3,6 +3,10 @@
         {
             "name": "devenv-runtime-local",
             "version": "v1.0.2"
+        },
+        {
+            "name": "test-package",
+            "version": "test-version"
         }
     ],
     "variables": {

--- a/testbench/test-exec/packages/test-package/test-version/echo-env.sh
+++ b/testbench/test-exec/packages/test-package/test-version/echo-env.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo `env`

--- a/testbench/test-exec/packages/test-package/test-version/hello-world.py
+++ b/testbench/test-exec/packages/test-package/test-version/hello-world.py
@@ -1,0 +1,1 @@
+print("Hello World!")

--- a/testbench/test-exec/packages/test-package/test-version/manifest.json
+++ b/testbench/test-exec/packages/test-package/test-version/manifest.json
@@ -7,6 +7,11 @@
                 {
                     "id": "echo-env",
                     "executable": "./echo-env.sh"
+                },
+                {
+                    "id": "executable-on-path",
+                    "executable": "python3",
+                    "args": ["./hello-world.py"]
                 }
             ]
         }

--- a/testbench/test-exec/packages/test-package/test-version/manifest.json
+++ b/testbench/test-exec/packages/test-package/test-version/manifest.json
@@ -1,0 +1,14 @@
+{
+    "components": [
+        {
+            "id": "test-component",
+            "type": "setup",
+            "programs": [
+                {
+                    "id": "echo-env",
+                    "executable": "./echo-env.sh"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Fixes the ENV variable assignment bug for all script started via the `exec` command and do not provide own arguments. Passing undefined to child_process.spawn causes weird behaviour in the binary built by PKG, hence we are now properly converting it to an empty array instead of passing undefined.