### PR TITLE
Adapt README title to avoid confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Velocitas CLI - The project manager for your Vehicle Apps
+Velocitas CLI - The project lifecycle manager for your Vehicle Apps
 =================================
 
 [![CI Workflow](https://github.com/eclipse-velocitas/cli/actions/workflows/ci.yml/badge.svg#branch=main)](https://github.com/eclipse-velocitas/cli/actions/workflows/ci.yml)


### PR DESCRIPTION
`Project manager` can lead to wrong assumptions and confusion, hence we should rename it to `Project lifecycle manager`