### PR TITLE
Make appmanifest optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "velocitas-cli",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@oclif/core": "^1.24.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "velocitas-cli",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/src/modules/app-manifest.ts
+++ b/src/modules/app-manifest.ts
@@ -49,6 +49,11 @@ export interface AppManifest {
 }
 
 export function readAppManifest(): AppManifest[] {
-    const config: AppManifest[] = JSON.parse(readFileSync(resolve(cwd(), './app/AppManifest.json'), 'utf-8'));
+    let config: AppManifest[] = [];
+    try {
+        config = JSON.parse(readFileSync(resolve(cwd(), './app/AppManifest.json'), 'utf-8'));
+    } catch (error) {
+        console.info('*** Info ***: No AppManifest found');
+    }
     return config;
 }

--- a/src/modules/app-manifest.ts
+++ b/src/modules/app-manifest.ts
@@ -15,6 +15,9 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { cwd } from 'node:process';
+import { DEFAULT_BUFFER_ENCODING } from './constants';
+
+const DEFAULT_APP_MANIFEST_PATH = resolve(cwd(), './app/AppManifest.json');
 
 export interface DockerImageReference {
     name: string;
@@ -51,7 +54,7 @@ export interface AppManifest {
 export function readAppManifest(): AppManifest[] {
     let config: AppManifest[] = [];
     try {
-        config = JSON.parse(readFileSync(resolve(cwd(), './app/AppManifest.json'), 'utf-8'));
+        config = JSON.parse(readFileSync(DEFAULT_APP_MANIFEST_PATH, DEFAULT_BUFFER_ENCODING));
     } catch (error) {
         console.info('*** Info ***: No AppManifest found');
     }

--- a/src/modules/constants.ts
+++ b/src/modules/constants.ts
@@ -1,0 +1,15 @@
+// Copyright (c) 2023 Robert Bosch GmbH
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License, Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export const DEFAULT_BUFFER_ENCODING = 'utf-8';

--- a/src/modules/package.ts
+++ b/src/modules/package.ts
@@ -20,6 +20,7 @@ import { existsSync, mkdirSync, readFileSync, rm } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { Component, ComponentType, deserializeComponentJSON } from './component';
+import { DEFAULT_BUFFER_ENCODING } from './constants';
 import { PackageConfig } from './project-config';
 
 export const GITHUB_ORG = 'eclipse-velocitas';
@@ -74,7 +75,10 @@ function getPackageRepo(packageName: string): string {
 export function readPackageManifest(packageConfig: PackageConfig): PackageManifest {
     try {
         const config: PackageManifest = deserializeComponentJSON(
-            readFileSync(join(getPackageFolderPath(), packageConfig.name, packageConfig.version, MANIFEST_FILE_NAME), 'utf-8')
+            readFileSync(
+                join(getPackageFolderPath(), packageConfig.name, packageConfig.version, MANIFEST_FILE_NAME),
+                DEFAULT_BUFFER_ENCODING
+            )
         );
         return config;
     } catch (error) {

--- a/src/modules/project-cache.ts
+++ b/src/modules/project-cache.ts
@@ -15,6 +15,7 @@
 import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, PathLike, readFileSync, writeFileSync } from 'node:fs';
 import { join, parse } from 'node:path';
+import { DEFAULT_BUFFER_ENCODING } from './constants';
 import { mapReplacer } from './helpers';
 import { getVelocitasRoot } from './package';
 
@@ -42,7 +43,7 @@ export class ProjectCache {
     static read(path: string = join(ProjectCache.getCacheDir(), FILE_NAME)): ProjectCache {
         const cache = new ProjectCache();
         try {
-            const data: any = JSON.parse(readFileSync(path, 'utf-8'));
+            const data: any = JSON.parse(readFileSync(path, DEFAULT_BUFFER_ENCODING));
             cache._data = new Map(Object.entries(data));
         } catch (e: any) {
             if (e.code !== 'ENOENT') {

--- a/src/modules/project-config.ts
+++ b/src/modules/project-config.ts
@@ -15,6 +15,7 @@
 import { PathLike, readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { cwd } from 'node:process';
+import { DEFAULT_BUFFER_ENCODING } from './constants';
 import { mapReplacer } from './helpers';
 
 export const DEFAULT_CONFIG_FILE_PATH = resolve(cwd(), './.velocitas.json');
@@ -46,7 +47,7 @@ export class ProjectConfig {
     }
 
     static read(path: PathLike = DEFAULT_CONFIG_FILE_PATH): ProjectConfig {
-        let config: ProjectConfig = new ProjectConfig(JSON.parse(readFileSync(path, 'utf-8')));
+        let config: ProjectConfig = new ProjectConfig(JSON.parse(readFileSync(path, DEFAULT_BUFFER_ENCODING)));
 
         if (config.variables) {
             config.variables = new Map(Object.entries(config.variables));
@@ -81,7 +82,7 @@ export class ProjectConfig {
 
     write(path: PathLike = DEFAULT_CONFIG_FILE_PATH): void {
         const configString = `${JSON.stringify(this, mapReplacer, 4)}\n`;
-        writeFileSync(path, configString, 'utf-8');
+        writeFileSync(path, configString, DEFAULT_BUFFER_ENCODING);
     }
 }
 

--- a/test/commands/exec/exec.test.ts
+++ b/test/commands/exec/exec.test.ts
@@ -64,7 +64,7 @@ class StubPty implements IPty {
 
 describe('exec', () => {
     test.do(() => {
-        mockFolders(true, true);
+        mockFolders({ velocitasConfig: true, installedComponents: true });
         setSpawnImplementation((command: string, args: string | string[], options: any) => new StubPty());
     })
         .finally(() => {
@@ -82,7 +82,7 @@ describe('exec', () => {
         });
 
     test.do(() => {
-        mockFolders(true, true);
+        mockFolders({ velocitasConfig: true, installedComponents: true });
         setSpawnImplementation((command: string, args: string | string[], options: any) => new StubPty());
     })
         .finally(() => {
@@ -102,7 +102,7 @@ describe('exec', () => {
         });
 
     test.do(() => {
-        mockFolders(true, true);
+        mockFolders({ velocitasConfig: true, installedComponents: true });
         setSpawnImplementation((command: string, args: string | string[], options: any) => new StubPty());
     })
         .finally(() => {
@@ -120,7 +120,24 @@ describe('exec', () => {
         });
 
     test.do(() => {
-        mockFolders(true, true);
+        mockFolders({ velocitasConfig: true, installedComponents: true, appManifest: false });
+    })
+        .finally(() => {
+            mockRestore();
+        })
+        .stdout()
+        .command([
+            'exec',
+            `${runtimeComponentManifestMock.components[1].id}`,
+            `${runtimeComponentManifestMock.components[1].programs[0].id}`,
+        ])
+        .it('should log warning when no AppManifest.json is found', (ctx) => {
+            console.error(ctx.stdout);
+            expect(ctx.stdout).to.contain('*** Info ***: No AppManifest found');
+        });
+
+    test.do(() => {
+        mockFolders({ velocitasConfig: true, installedComponents: true });
         setSpawnImplementation((command: string, args: string | string[], options: any) => new StubPty());
     })
         .finally(() => {
@@ -134,7 +151,7 @@ describe('exec', () => {
         .it('throws error when program is not found in specified runtime component');
 
     test.do(() => {
-        mockFolders(true, true);
+        mockFolders({ velocitasConfig: true, installedComponents: true });
         setSpawnImplementation((command: string, args: string | string[], options: any) => new StubPty());
     })
         .finally(() => {

--- a/test/commands/init/init.test.ts
+++ b/test/commands/init/init.test.ts
@@ -36,7 +36,7 @@ function createPackageArchive(components = new Array<Component>()) {
 
 describe('init', () => {
     test.do(() => {
-        mockFolders(true);
+        mockFolders({ velocitasConfig: true });
     })
         .finally(() => {
             mockRestore();
@@ -79,7 +79,7 @@ describe('init', () => {
         });
 
     test.do(() => {
-        mockFolders(true);
+        mockFolders({ velocitasConfig: true });
     })
         .finally(() => {
             mockRestore();
@@ -107,7 +107,7 @@ describe('init', () => {
         });
 
     test.do(() => {
-        mockFolders(true, true);
+        mockFolders({ velocitasConfig: true, installedComponents: true });
     })
         .finally(() => {
             mockRestore();
@@ -128,6 +128,19 @@ describe('init', () => {
         });
 
     test.do(() => {
+        mockFolders({ velocitasConfig: true, installedComponents: true, appManifest: false });
+    })
+        .finally(() => {
+            mockRestore();
+        })
+        .stdout()
+        .command(['init', '-v'])
+        .it('should log warning when no AppManifest.json is found', (ctx) => {
+            console.error(ctx.stdout);
+            expect(ctx.stdout).to.contain('*** Info ***: No AppManifest found');
+        });
+
+    test.do(() => {
         mockFolders();
     })
         .finally(() => {
@@ -142,7 +155,7 @@ describe('init', () => {
         });
 
     test.do(() => {
-        mockFolders(true);
+        mockFolders({ velocitasConfig: true });
     })
         .finally(() => {
             mockRestore();
@@ -175,7 +188,7 @@ describe('init', () => {
         });
 
     test.do(() => {
-        mockFolders(true);
+        mockFolders({ velocitasConfig: true });
     })
         .finally(() => {
             mockRestore();

--- a/test/commands/package/package.test.ts
+++ b/test/commands/package/package.test.ts
@@ -18,7 +18,7 @@ import { mockFolders, mockRestore, userHomeDir } from '../../utils/mockfs';
 
 describe('package', () => {
     test.do(() => {
-        mockFolders(true, true);
+        mockFolders({ velocitasConfig: true, installedComponents: true });
     })
         .finally(() => {
             mockRestore();
@@ -30,7 +30,7 @@ describe('package', () => {
         });
 
     test.do(() => {
-        mockFolders(true, true);
+        mockFolders({ velocitasConfig: true, installedComponents: true });
     })
         .finally(() => {
             mockRestore();
@@ -44,7 +44,7 @@ describe('package', () => {
         });
 
     test.do(() => {
-        mockFolders(true);
+        mockFolders({ velocitasConfig: true });
     })
         .finally(() => {
             mockRestore();
@@ -55,7 +55,7 @@ describe('package', () => {
         .it('throws error when configured component cannot be found');
 
     test.do(() => {
-        mockFolders(true, true);
+        mockFolders({ velocitasConfig: true, installedComponents: true });
     })
         .finally(() => {
             mockRestore();

--- a/test/commands/sync/sync.test.ts
+++ b/test/commands/sync/sync.test.ts
@@ -18,7 +18,7 @@ import { mockFolders, mockRestore } from '../../utils/mockfs';
 
 describe('sync', () => {
     test.do(() => {
-        mockFolders(true, true);
+        mockFolders({ velocitasConfig: true, installedComponents: true });
     })
         .finally(() => {
             mockRestore();

--- a/test/commands/upgrade/upgrade.test.ts
+++ b/test/commands/upgrade/upgrade.test.ts
@@ -29,7 +29,7 @@ describe('upgrade', () => {
     const mockedNewVersion = 'v2.0.0';
 
     test.do(() => {
-        mockFolders(true);
+        mockFolders({ velocitasConfig: true });
     })
         .finally(() => {
             mockRestore();
@@ -55,7 +55,7 @@ describe('upgrade', () => {
         });
 
     test.do(() => {
-        mockFolders(true, true);
+        mockFolders({ velocitasConfig: true, installedComponents: true });
     })
         .finally(() => {
             mockRestore();
@@ -77,7 +77,7 @@ describe('upgrade', () => {
         });
 
     test.do(() => {
-        mockFolders(true, true);
+        mockFolders({ velocitasConfig: true, installedComponents: true });
     })
         .finally(() => {
             mockRestore();
@@ -103,7 +103,7 @@ describe('upgrade', () => {
         });
 
     test.do(() => {
-        mockFolders(true);
+        mockFolders({ velocitasConfig: true });
     })
         .finally(() => {
             mockRestore();
@@ -138,7 +138,7 @@ describe('upgrade', () => {
         });
 
     test.do(() => {
-        mockFolders(true);
+        mockFolders({ velocitasConfig: true });
     })
         .finally(() => {
             mockRestore();
@@ -164,7 +164,7 @@ describe('upgrade', () => {
         });
 
     test.do(() => {
-        mockFolders(true);
+        mockFolders({ velocitasConfig: true });
     })
         .finally(() => {
             mockRestore();
@@ -193,7 +193,7 @@ describe('upgrade', () => {
         });
 
     test.do(() => {
-        mockFolders(true, true);
+        mockFolders({ velocitasConfig: true, installedComponents: true });
     })
         .finally(() => {
             mockRestore();
@@ -215,7 +215,7 @@ describe('upgrade', () => {
         });
 
     test.do(() => {
-        mockFolders(true, true);
+        mockFolders({ velocitasConfig: true, installedComponents: true });
     })
         .finally(() => {
             mockRestore();
@@ -255,7 +255,7 @@ describe('upgrade', () => {
         });
 
     test.do(() => {
-        mockFolders(true, true);
+        mockFolders({ velocitasConfig: true, installedComponents: true });
     })
         .finally(() => {
             mockRestore();
@@ -296,7 +296,7 @@ describe('upgrade', () => {
         });
 
     test.do(() => {
-        mockFolders(true, true);
+        mockFolders({ velocitasConfig: true, installedComponents: true });
     })
         .finally(() => {
             mockRestore();

--- a/test/helpers/cache.ts
+++ b/test/helpers/cache.ts
@@ -14,15 +14,16 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'node:path';
+import { DEFAULT_BUFFER_ENCODING } from '../../src/modules/constants';
 import { ProjectCache } from '../../src/modules/project-cache';
 
 export const getCacheData = () => {
-    return JSON.parse(readFileSync(`${ProjectCache.getCacheDir()}/cache.json`, 'utf-8'));
+    return JSON.parse(readFileSync(`${ProjectCache.getCacheDir()}/cache.json`, DEFAULT_BUFFER_ENCODING));
 };
 
 export function writeCacheData(cacheData: any) {
     if (!existsSync(ProjectCache.getCacheDir())) {
         mkdirSync(ProjectCache.getCacheDir(), { recursive: true });
     }
-    return writeFileSync(join(ProjectCache.getCacheDir(), 'cache.json'), JSON.stringify(cacheData), { encoding: 'utf-8' });
+    return writeFileSync(join(ProjectCache.getCacheDir(), 'cache.json'), JSON.stringify(cacheData), { encoding: DEFAULT_BUFFER_ENCODING });
 }

--- a/test/system-test/exec.stest.ts
+++ b/test/system-test/exec.stest.ts
@@ -19,6 +19,7 @@ import { homedir } from 'node:os';
 import { join } from 'path';
 import { cwd } from 'process';
 import YAML from 'yaml';
+import { DEFAULT_BUFFER_ENCODING } from '../../src/modules/constants';
 
 const VELOCITAS_PROCESS = join('..', '..', process.env['VELOCITAS_PROCESS'] ? process.env['VELOCITAS_PROCESS'] : 'velocitas');
 const TEST_ROOT = cwd();
@@ -33,7 +34,7 @@ describe('CLI command', () => {
         });
 
         it('should be able to exec all exposed program specs of runtime-local', async () => {
-            const packageOutput = spawnSync(VELOCITAS_PROCESS, ['package', 'devenv-runtime-local'], { encoding: 'utf-8' });
+            const packageOutput = spawnSync(VELOCITAS_PROCESS, ['package', 'devenv-runtime-local'], { encoding: DEFAULT_BUFFER_ENCODING });
             const parsedPackageOutput = YAML.parse(packageOutput.stdout.toString());
             const runtimeLocalComponent = parsedPackageOutput['devenv-runtime-local'].components.find(
                 (component: any) => component.id === 'runtime-local'
@@ -48,7 +49,7 @@ describe('CLI command', () => {
         });
 
         it('should pass environment variables to the spawned process', async () => {
-            const result = spawnSync(VELOCITAS_PROCESS, ['exec', 'test-component', 'echo-env'], { encoding: 'utf-8' });
+            const result = spawnSync(VELOCITAS_PROCESS, ['exec', 'test-component', 'echo-env'], { encoding: DEFAULT_BUFFER_ENCODING });
 
             expect(result.stdout).to.contain('VELOCITAS_WORKSPACE_DIR=');
             expect(result.stdout).to.contain('VELOCITAS_CACHE_DATA=');
@@ -56,19 +57,21 @@ describe('CLI command', () => {
         });
 
         it('should be able to run executables that are on the path', () => {
-            const result = spawnSync(VELOCITAS_PROCESS, ['exec', 'test-component', 'executable-on-path'], { encoding: 'utf-8' });
+            const result = spawnSync(VELOCITAS_PROCESS, ['exec', 'test-component', 'executable-on-path'], {
+                encoding: DEFAULT_BUFFER_ENCODING,
+            });
 
             expect(result.stdout).to.be.equal('Hello World!\r\n');
         });
 
         it('should be able to let programs set cache values', () => {
-            const result = spawnSync(VELOCITAS_PROCESS, ['exec', 'test-component', 'set-cache'], { encoding: 'utf-8' });
+            const result = spawnSync(VELOCITAS_PROCESS, ['exec', 'test-component', 'set-cache'], { encoding: DEFAULT_BUFFER_ENCODING });
 
             expect(result.error).to.be.undefined;
         });
 
         it('should be able to let programs get cache values', () => {
-            const result = spawnSync(VELOCITAS_PROCESS, ['exec', 'test-component', 'get-cache'], { encoding: 'utf-8' });
+            const result = spawnSync(VELOCITAS_PROCESS, ['exec', 'test-component', 'get-cache'], { encoding: DEFAULT_BUFFER_ENCODING });
 
             expect(result.stdout).to.contain('my_cache_key');
             expect(result.stdout).to.contain('my_cache_value');
@@ -83,13 +86,15 @@ describe('CLI command', () => {
         });
 
         it('should be able to run programs which read from stdin', () => {
-            const result = spawnSync(VELOCITAS_PROCESS, ['exec', 'test-component', 'tty'], { encoding: 'utf-8' });
+            const result = spawnSync(VELOCITAS_PROCESS, ['exec', 'test-component', 'tty'], { encoding: DEFAULT_BUFFER_ENCODING });
 
             expect(result.error).to.be.undefined;
         });
 
         it('should append user-provided args to the default args', () => {
-            const result = spawnSync(VELOCITAS_PROCESS, ['exec', 'test-component', 'print-args', 'hello', 'world'], { encoding: 'utf-8' });
+            const result = spawnSync(VELOCITAS_PROCESS, ['exec', 'test-component', 'print-args', 'hello', 'world'], {
+                encoding: DEFAULT_BUFFER_ENCODING,
+            });
 
             const lines = result.stdout.split('\r\n');
             expect(lines.length).to.be.equal(6);

--- a/test/utils/mockfs.ts
+++ b/test/utils/mockfs.ts
@@ -21,7 +21,9 @@ export const userHomeDir = os.homedir();
 const runtimeComponentPath = `${userHomeDir}/.velocitas/packages/${velocitasConfigMock.packages[0].name}/${velocitasConfigMock.packages[0].version}`;
 const setupComponentPath = `${userHomeDir}/.velocitas/packages/${velocitasConfigMock.packages[1].name}/${velocitasConfigMock.packages[1].version}`;
 
-export const mockFolders = (withVelocitasConfig: boolean = false, withInstalledComponents: boolean = false) => {
+type MockConfig = { velocitasConfig?: boolean; installedComponents?: boolean; appManifest?: boolean };
+
+export const mockFolders = (mockConfig?: MockConfig) => {
     const mockfsConf: any = {
         'package.json': mockfs.load(path.resolve(__dirname, '../../package.json')),
         'tsconfig.json': mockfs.load(path.resolve(__dirname, '../../tsconfig.json')),
@@ -32,10 +34,13 @@ export const mockFolders = (withVelocitasConfig: boolean = false, withInstalledC
             'AppManifest.json': JSON.stringify(appManifestMock),
         },
     };
-    if (withVelocitasConfig) {
+    if (mockConfig && mockConfig.appManifest === false) {
+        delete mockfsConf.app;
+    }
+    if (mockConfig && mockConfig.velocitasConfig) {
         mockfsConf['.velocitas.json'] = JSON.stringify(velocitasConfigMock);
     }
-    if (withInstalledComponents) {
+    if (mockConfig && mockConfig.installedComponents) {
         mockfsConf[runtimeComponentPath] = {
             'manifest.json': JSON.stringify(runtimeComponentManifestMock),
             src: {},


### PR DESCRIPTION
This PR should add the possibility to run the Velocitas CLI without having an AppManifest in the VehicleApp repository. (Which will be the deprecated/old approach of handling VehicleApp dependencies)