### PR TITLE
Fix upper version of tested NodeJS versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,8 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        node_version: [lts/-1, lts/*, latest]
+        # TODO: eclipse-velocitas/cli/issues/141
+        node_version: [lts/-1, lts/*, 20.4.0]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Fixes the upper version of tested NodeJS releases since there is a bug in mock-fs with the latest NodeJS:

eclipse-velocitas/cli/issues/141