### PR TITLE
fix: Keep backwards compatibility with array based app manifests

### DIFF
--- a/src/modules/app-manifest.ts
+++ b/src/modules/app-manifest.ts
@@ -20,7 +20,7 @@ import { DEFAULT_BUFFER_ENCODING } from './constants';
 const DEFAULT_APP_MANIFEST_PATH = resolve(cwd(), './app/AppManifest.json');
 
 export function readAppManifest(appManifestPath: string = DEFAULT_APP_MANIFEST_PATH): any | undefined {
-    let manifest: any = undefined;
+    let manifest: any;
 
     if (existsSync(appManifestPath)) {
         try {

--- a/src/modules/app-manifest.ts
+++ b/src/modules/app-manifest.ts
@@ -20,12 +20,16 @@ import { DEFAULT_BUFFER_ENCODING } from './constants';
 const DEFAULT_APP_MANIFEST_PATH = resolve(cwd(), './app/AppManifest.json');
 
 export function readAppManifest(appManifestPath: string = DEFAULT_APP_MANIFEST_PATH): any | undefined {
-    let config: any = undefined;
+    let manifest: any = undefined;
 
     if (existsSync(appManifestPath)) {
         try {
             const file = readFileSync(appManifestPath, DEFAULT_BUFFER_ENCODING);
-            config = JSON.parse(file);
+            manifest = JSON.parse(file);
+            if (manifest instanceof Array) {
+                // for backwards compatibility we use the first entry from the array
+                manifest = manifest[0];
+            }
         } catch (error) {
             console.error(`Unable to read App Manifest: '${error}'`);
             throw error;
@@ -34,5 +38,5 @@ export function readAppManifest(appManifestPath: string = DEFAULT_APP_MANIFEST_P
         console.info('*** Info ***: No AppManifest found');
     }
 
-    return config;
+    return manifest;
 }

--- a/test/system-test/exec.stest.ts
+++ b/test/system-test/exec.stest.ts
@@ -20,6 +20,7 @@ import { join } from 'path';
 import { cwd } from 'process';
 import YAML from 'yaml';
 import { DEFAULT_BUFFER_ENCODING } from '../../src/modules/constants';
+import { readFileSync } from 'fs';
 
 const VELOCITAS_PROCESS = join('..', '..', process.env['VELOCITAS_PROCESS'] ? process.env['VELOCITAS_PROCESS'] : 'velocitas');
 const TEST_ROOT = cwd();
@@ -51,10 +52,11 @@ describe('CLI command', () => {
         it('should pass environment variables to the spawned process', async () => {
             const result = spawnSync(VELOCITAS_PROCESS, ['exec', 'test-component', 'echo-env'], { encoding: DEFAULT_BUFFER_ENCODING });
 
+            const expectedString = JSON.stringify(JSON.parse(readFileSync('./app/AppManifest.json', 'utf-8')));
             expect(result.stdout).to.contain('VELOCITAS_WORKSPACE_DIR=');
             expect(result.stdout).to.contain('VELOCITAS_CACHE_DATA=');
             expect(result.stdout).to.contain('VELOCITAS_CACHE_DIR=');
-            expect(result.stdout).to.contain('VELOCITAS_APP_MANIFEST=');
+            expect(result.stdout).to.contain(`VELOCITAS_APP_MANIFEST=${expectedString}`);
             expect(result.stdout).to.contain(`VELOCITAS_PACKAGE_DIR=${VELOCITAS_HOME}/packages/test-package/test-version`);
         });
 

--- a/test/unit/app-manifest.test.ts
+++ b/test/unit/app-manifest.test.ts
@@ -20,7 +20,8 @@ import { expect } from 'chai';
 describe('app-manifest - module', () => {
     before(() => {
         const mockfsConf: any = {
-            '/AppManifest.json': 'foo',
+            '/AppManifestInvalid.json': 'foo',
+            '/AppManifestValid.json': '{ "name": "AppName", "manifestVersion": "v3" }'
         };
         mockfs(mockfsConf, { createCwd: false });
     });
@@ -30,7 +31,14 @@ describe('app-manifest - module', () => {
         });
 
         it('should throw an error if file is present, but cannot be read.', () => {
-            expect(readAppManifest.bind(readAppManifest, '/AppManifest.json')).to.throw();
+            expect(readAppManifest.bind(readAppManifest, '/AppManifestInvalid.json')).to.throw();
+        });
+
+        it('should read the file and return proper content', () => {
+            const appManifest = readAppManifest('/AppManifestValid.json');
+
+            expect(appManifest['name']).to.be.eq('AppName');
+            expect(appManifest['manifestVersion']).to.be.eq('v3');
         });
     });
     after(() => {

--- a/test/unit/app-manifest.test.ts
+++ b/test/unit/app-manifest.test.ts
@@ -21,7 +21,8 @@ describe('app-manifest - module', () => {
     before(() => {
         const mockfsConf: any = {
             '/AppManifestInvalid.json': 'foo',
-            '/AppManifestValid.json': '{ "name": "AppName", "manifestVersion": "v3" }'
+            '/AppManifestValid.json': '{ "name": "AppName", "manifestVersion": "v3" }',
+            '/AppManifestArray.json': '[ { "name": "AppName", "manifestVersion": "v3" } ]'
         };
         mockfs(mockfsConf, { createCwd: false });
     });
@@ -36,6 +37,13 @@ describe('app-manifest - module', () => {
 
         it('should read the file and return proper content', () => {
             const appManifest = readAppManifest('/AppManifestValid.json');
+
+            expect(appManifest['name']).to.be.eq('AppName');
+            expect(appManifest['manifestVersion']).to.be.eq('v3');
+        });
+
+        it('should omit the root array, if it exists and return proper content', () => {
+            const appManifest = readAppManifest('/AppManifestArray.json');
 
             expect(appManifest['name']).to.be.eq('AppName');
             expect(appManifest['manifestVersion']).to.be.eq('v3');

--- a/testbench/test-exec/app/AppManifest.json
+++ b/testbench/test-exec/app/AppManifest.json
@@ -1,21 +1,19 @@
-[
-    {
-        "name": "TestExec",
-        "vehicleModel": {
-            "src": "https://github.com/COVESA/vehicle_signal_specification/releases/download/v3.0/vss_rel_3.0.json",
-            "datapoints": [
-                {
-                    "path": "Vehicle.Speed",
-                    "required": "true",
-                    "access": "read"
+{
+    "name": "TestExec",
+    "interfaces": [
+        {
+            "type": "vehicle-signal-interface",
+            "config": {
+                "src": "https://github.com/COVESA/vehicle_signal_specification/releases/download/v3.0/vss_rel_3.0.json",
+                "datapoints": {
+                    "required": [
+                        {
+                            "path": "Vehicle.Speed",
+                            "access": "read"
+                        }
+                    ]
                 }
-            ]
-        },
-        "runtime": [
-            "grpc://sdv.databroker.v1.Broker/GetDatapoints",
-            "grpc://sdv.databroker.v1.Broker/Subscribe",
-            "grpc://sdv.databroker.v1.Broker/SetDatapoints",
-            "mqtt"
-        ]
-    }
-]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
The previous commit changed how AppManifest is read in case it is an array b/c it was breaking backwards compatibility.