### PR TITLE
fix: handle invalid .velocitas.json correctly

### DIFF
--- a/src/commands/init/index.ts
+++ b/src/commands/init/index.ts
@@ -110,6 +110,7 @@ Velocitas project found!
                 }
             }
         } else {
+            this.log('Directory is no velocitas project, yet!');
             this.log('... Creating .velocitas.json at the root of your repository.');
             projectConfig = new ProjectConfig();
             projectConfig.write();

--- a/src/commands/init/index.ts
+++ b/src/commands/init/index.ts
@@ -84,36 +84,34 @@ Velocitas project found!
 
         const appManifestData = readAppManifest();
 
-        if (ProjectConfig.isAvailable()) {
-            projectConfig = ProjectConfig.read();
+        if (!ProjectConfig.isAvailable()) {
+            this.log('... Directory is no velocitas project. Creating .velocitas.json at the root of your repository.');
+            projectConfig = new ProjectConfig();
+            projectConfig.write();
+        }
+        projectConfig = ProjectConfig.read();
 
-            for (const packageConfig of projectConfig.packages) {
-                if (!flags.force && packageConfig.isPackageInstalled()) {
-                    this.log(`... '${packageConfig.getPackageName()}:${packageConfig.version}' already initialized.`);
-                    continue;
-                }
-                this.log(`... Downloading package: '${packageConfig.getPackageName()}:${packageConfig.version}'`);
-                await packageConfig.downloadPackageVersion(flags.verbose);
-                const packageManifest = packageConfig.readPackageManifest();
-                for (const component of packageManifest.components) {
-                    try {
-                        await runPostInitHook(component, packageConfig, projectConfig, appManifestData, flags.verbose);
-                    } catch (e) {
-                        if (e instanceof ExecExitError) {
-                            this.error(e.message, { exit: e.exitCode });
-                        } else if (e instanceof Error) {
-                            this.error(e.message);
-                        } else {
-                            this.error(`An unexpected error occured during initialization of component: ${component.id}`);
-                        }
+        for (const packageConfig of projectConfig.packages) {
+            if (!flags.force && packageConfig.isPackageInstalled()) {
+                this.log(`... '${packageConfig.getPackageName()}:${packageConfig.version}' already initialized.`);
+                continue;
+            }
+            this.log(`... Downloading package: '${packageConfig.getPackageName()}:${packageConfig.version}'`);
+            await packageConfig.downloadPackageVersion(flags.verbose);
+            const packageManifest = packageConfig.readPackageManifest();
+            for (const component of packageManifest.components) {
+                try {
+                    await runPostInitHook(component, packageConfig, projectConfig, appManifestData, flags.verbose);
+                } catch (e) {
+                    if (e instanceof ExecExitError) {
+                        this.error(e.message, { exit: e.exitCode });
+                    } else if (e instanceof Error) {
+                        this.error(e.message);
+                    } else {
+                        this.error(`An unexpected error occured during initialization of component: ${component.id}`);
                     }
                 }
             }
-        } else {
-            this.log('Directory is no velocitas project, yet!');
-            this.log('... Creating .velocitas.json at the root of your repository.');
-            projectConfig = new ProjectConfig();
-            projectConfig.write();
         }
     }
 }

--- a/test/commands/init/init.test.ts
+++ b/test/commands/init/init.test.ts
@@ -87,7 +87,9 @@ describe('init', () => {
         .command(['init'])
         .it('creates config file from default velocitas.json', (ctx) => {
             expect(ctx.stdout).to.contain('Initializing Velocitas packages ...');
-            expect(ctx.stdout).to.contain('... Creating .velocitas.json at the root of your repository.');
+            expect(ctx.stdout).to.contain(
+                '... Directory is no velocitas project. Creating .velocitas.json at the root of your repository.',
+            );
             expect(fs.existsSync(`${process.cwd()}/.velocitas.json`)).to.be.true;
         });
 

--- a/test/unit/project-config.test.ts
+++ b/test/unit/project-config.test.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2023 Robert Bosch GmbH
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License, Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import 'mocha';
+import mockfs from 'mock-fs';
+import { ProjectConfig } from '../../src/modules/project-config';
+import { expect } from 'chai';
+
+describe('project-config - module', () => {
+    before(() => {
+        const mockfsConf: any = {
+            '/.velocitasInvalid.json': 'foo',
+            '/.velocitasValid.json': '{ "packages": [], "variables": {} }',
+        };
+        mockfs(mockfsConf, { createCwd: false });
+    });
+    describe('.velocitas.json reading', () => {
+        it('should return false when there is no .velocitas.json at the provided path.', () => {
+            expect(ProjectConfig.isAvailable('/.noVelocitas.json')).to.be.false;
+        });
+        it('should return true when there is a .velocitas.json at the provided path.', () => {
+            expect(ProjectConfig.isAvailable('/.velocitasValid.json')).to.be.true;
+        });
+    });
+    describe('.velocitas.json parsing', () => {
+        it('should throw an error when .velocitas.json is invalid.', () => {
+            expect(ProjectConfig.read.bind(ProjectConfig.read, '/.velocitasInvalid.json')).to.throw();
+        });
+        it('should be able to read the ProjectConfig when .velocitas.json is valid.', () => {
+            expect(ProjectConfig.read.bind(ProjectConfig.read, '/.velocitasValid.json')).to.not.throw();
+        });
+    });
+    after(() => {
+        mockfs.restore();
+    });
+});

--- a/test/unit/project-config.test.ts
+++ b/test/unit/project-config.test.ts
@@ -37,7 +37,7 @@ describe('project-config - module', () => {
         it('should throw an error when .velocitas.json is invalid.', () => {
             expect(ProjectConfig.read.bind(ProjectConfig.read, '/.velocitasInvalid.json')).to.throw();
         });
-        it('should be able to read the ProjectConfig when .velocitas.json is valid.', () => {
+        it('should read the ProjectConfig when .velocitas.json is valid.', () => {
             expect(ProjectConfig.read.bind(ProjectConfig.read, '/.velocitasValid.json')).to.not.throw();
         });
     });


### PR DESCRIPTION
This PR fixes handling of the .velocitas.json correctly:

- Give error message if file exists but contains invalid json code
- Just create default if file is not existing