### PR TITLE
fix: Support multiple setup components for sync

### DIFF
--- a/src/commands/sync/index.ts
+++ b/src/commands/sync/index.ts
@@ -22,7 +22,7 @@ export default class Sync extends Command {
     static description = 'Syncs Velocitas components into your repo.';
 
     static examples = [
-        `$ velocitas update MyAwesomeApp --lang cpp
+        `$ velocitas sync
 Syncing Velocitas components!
 ... syncing 'devenv-github-workflows'
 ... syncing 'devenv-github-templates'`,
@@ -33,7 +33,7 @@ Syncing Velocitas components!
         const projectConfig = ProjectConfig.read(`v${this.config.version}`);
         const setupComponents = findComponentsByType(projectConfig, ComponentType.setup);
         for (const setupComponent of setupComponents) {
-            this.log(`... syncing '${setupComponent[0].getPackageName()}'`);
+            this.log(`... syncing '${setupComponent[2].id}'`);
 
             const componentConfig = getComponentConfig(setupComponent[0], setupComponent[2].id);
             const variables = VariableCollection.build(projectConfig, setupComponent[0], componentConfig, setupComponent[2]);

--- a/src/modules/component.ts
+++ b/src/modules/component.ts
@@ -12,7 +12,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { getComponentByType, PackageConfig, PackageManifest } from './package';
+import { getComponentsByType, PackageConfig, PackageManifest } from './package';
 import { ComponentConfig, ProjectConfig } from './project-config';
 import { VariableDefinition } from './variables';
 
@@ -105,9 +105,11 @@ export function findComponentsByType<TComponentType extends Component>(
 ): Array<[PackageConfig, PackageManifest, TComponentType]> {
     const result = new Array<[PackageConfig, PackageManifest, TComponentType]>();
     for (const packageConfig of projectConfig.packages) {
-        const componentManifest = packageConfig.readPackageManifest();
+        const packageManifest = packageConfig.readPackageManifest();
         try {
-            result.push([packageConfig, componentManifest, getComponentByType(componentManifest, type) as TComponentType]);
+            for(const component of getComponentsByType(packageManifest, type)) {
+                result.push([packageConfig, packageManifest, component as TComponentType]);
+            }
         } catch (e) {}
     }
 

--- a/src/modules/package.ts
+++ b/src/modules/package.ts
@@ -132,10 +132,6 @@ function getPackageFolderPath(): string {
     return join(getVelocitasRoot(), 'packages');
 }
 
-export function getComponentByType(packageManifest: PackageManifest, type: ComponentType): Component {
-    const component = packageManifest.components.find((component: Component) => component.type === type);
-    if (component === undefined) {
-        throw new TypeError(`No Subcomponent with type "${type}" found!`);
-    }
-    return component;
+export function getComponentsByType(packageManifest: PackageManifest, type: ComponentType): Component[] {
+    return packageManifest.components.filter((component: Component) => component.type === type);
 }

--- a/test/commands/sync/sync.test.ts
+++ b/test/commands/sync/sync.test.ts
@@ -13,7 +13,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { expect, test } from '@oclif/test';
-import { velocitasConfigMock } from '../../utils/mockConfig';
+import { runtimeComponentManifestMock, setupComponentManifestMock, velocitasConfigMock } from '../../utils/mockConfig';
 import { mockFolders, mockRestore } from '../../utils/mockfs';
 
 describe('sync', () => {
@@ -27,7 +27,7 @@ describe('sync', () => {
         .command(['sync'])
         .it('syncing components into project directory', (ctx) => {
             expect(ctx.stdout).to.contain('Syncing Velocitas components!');
-            expect(ctx.stdout).to.contain(`... syncing '${velocitasConfigMock.packages[1].name}'`);
-            expect(ctx.stdout).to.not.contain(`... syncing '${velocitasConfigMock.packages[0].name}'`);
+            expect(ctx.stdout).to.contain(`... syncing '${setupComponentManifestMock.components[0].id}'`);
+            expect(ctx.stdout).to.not.contain(`... syncing '${runtimeComponentManifestMock.components[0].id}'`);
         });
 });


### PR DESCRIPTION
The sync command is calling `getComponentByType` under the hood which returns only one component rather than all setup components in the package. This fix replaces `getComponentByType` with `getComponentsByType` to support multiple setup type components in a package.