### PR TITLE
Add Package Parameter to Init

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,16 +2,28 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Run tests",
+            "type": "node",
             "request": "launch",
-            "runtimeArgs": [
-                "test",
-            ],
+            "name": "Debug CLI - init all",
+            "cwd": "${workspaceFolder}/vehicle-app-repo",
+            "program": "${workspaceFolder}/bin/dev",
+            "args": ["init"]
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Debug CLI - init with package and version",
+            "cwd": "${workspaceFolder}/vehicle-app-repo",
+            "program": "${workspaceFolder}/bin/dev",
+            "args": ["init", "-p", "devenv-runtimes@v3.0.0"]
+        },
+        {
+            "name": "Run tests",
+            "type": "node",
+            "request": "launch",
+            "runtimeArgs": ["test"],
             "runtimeExecutable": "npm",
-            "skipFiles": [
-                "<node_internals>/**"
-            ],
-            "type": "node"
+            "skipFiles": ["<node_internals>/**"]
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,14 +10,6 @@
             "args": ["init"]
         },
         {
-            "type": "node",
-            "request": "launch",
-            "name": "Debug CLI - init with package and version",
-            "cwd": "${workspaceFolder}/vehicle-app-repo",
-            "program": "${workspaceFolder}/bin/dev",
-            "args": ["init", "-p", "devenv-runtimes@v3.0.0"]
-        },
-        {
             "name": "Run tests",
             "type": "node",
             "request": "launch",

--- a/README.md
+++ b/README.md
@@ -309,12 +309,14 @@ Initializes Velocitas Vehicle App
 
 ```
 USAGE
-  $ velocitas init [-v] [-f] [--no-hooks]
+  $ velocitas init [-p PACKAGE] [-s VERSION_SPECIFIER] [-v] [-f] [--no-hooks]
 
 FLAGS
-  -f, --force    Force (re-)download packages
-  -v, --verbose  Enable verbose logging
-  --no-hooks     Skip post init hooks
+  -p, --package   Package to initialize 
+  -s, --specifier Version specifier for the specified package
+  -f, --force     Force (re-)download packages
+  -v, --verbose   Enable verbose logging
+  --no-hooks      Skip post init hooks
 
 DESCRIPTION
   Initializes Velocitas Vehicle App
@@ -327,6 +329,18 @@ EXAMPLES
   ... Downloading package: 'devenv-runtimes:vx.x.x'
   ... Downloading package: 'devenv-github-templates:vx.x.x'
   ... Downloading package: 'devenv-github-workflows:vx.x.x'
+
+  $ velocitas init -p devenv-runtimes
+  Initializing Velocitas packages ...
+  ... Package 'devenv-runtimes:vx.x.x' added to .velocitas.json
+  ... Downloading package: 'devenv-runtimes:vx.x.x'
+  ... > Running post init hook for ...'
+
+  $ velocitas init -p devenv-runtimes -s v3.0.0
+  Initializing Velocitas packages ...
+  ... Package 'devenv-runtimes:v3.0.0' added to .velocitas.json
+  ... Downloading package: 'devenv-runtimes:v3.0.0'
+  ... > Running post init hook for ...
 ```
 
 _See code: [src/commands/init/index.ts](src/commands/init/index.ts)_

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ USAGE
   $ velocitas init [-p PACKAGE] [-s VERSION_SPECIFIER] [-v] [-f] [--no-hooks]
 
 FLAGS
-  -p, --package   Package to initialize 
+  -p, --package   Package to initialize
   -s, --specifier Version specifier for the specified package
   -f, --force     Force (re-)download packages
   -v, --verbose   Enable verbose logging

--- a/src/commands/init/index.ts
+++ b/src/commands/init/index.ts
@@ -69,16 +69,14 @@ export default class Init extends Command {
         package: Flags.string({
             char: 'p',
             aliases: ['package'],
-            description: `Specify a specific package for initialisation. For standard packages the name can be used, e.g.: devenv-runtimes. 
-            For custom packages a git URL can be used, e.g: https://github.com/eclipse-velocitas/devenv-github-workflows.git.`,
+            description: `Package to initialize`,
             required: false,
             default: '',
         }),
         specifier: Flags.string({
             char: 's',
             aliases: ['specifier'],
-            description: `The specifier can be used to provide a specific version of the package to be used. 
-            A git tag (e.g. 'v3.0.0') or commit hash (e.g. '123abc45') can be provided as input`,
+            description: `Version specifier for the specified package`,
             required: false,
             default: '',
             dependsOn: ['package'],

--- a/src/commands/init/index.ts
+++ b/src/commands/init/index.ts
@@ -116,8 +116,12 @@ export default class Init extends Command {
                 `... Updating '${requestedPackageConfig.getPackageName()}' to version '${requestedPackageConfig.version}' in .velocitas.json`,
             );
         } else {
-            projectConfig.addPackageConfig(requestedPackageConfig);
-            this.log(`... Package '${requestedPackageConfig.getPackageName()}:${requestedPackageConfig.version}' added to .velocitas.json`);
+            const isAdded = projectConfig.addPackageConfig(requestedPackageConfig);
+            if (isAdded) {
+                this.log(
+                    `... Package '${requestedPackageConfig.getPackageName()}:${requestedPackageConfig.version}' added to .velocitas.json`,
+                );
+            }
         }
 
         await this._ensurePackagesAreDownloaded([requestedPackageConfig], flags);

--- a/src/modules/project-config.ts
+++ b/src/modules/project-config.ts
@@ -192,7 +192,7 @@ export class ProjectConfig {
     }
 
     /**
-     * Adds a new packageConfig to the project. This method  Won't add a new package if a package with the
+     * Adds a new packageConfig to the project. This method won't add a new package if a package with the
      * same name already exists. Different versions are not taken into consideration. If updating the
      * version of a packageConfig is required use #updatePackageConfig.
      *

--- a/src/modules/project-config.ts
+++ b/src/modules/project-config.ts
@@ -181,9 +181,10 @@ export class ProjectConfig {
     }
 
     /**
-     * Searches through all / only the installed packageConfigs for the packageConfig with the specified name and returns it. If no packageConfig is found undefined is returned.
+     * Searches through all / only the installed packageConfigs for the packageConfig with the specified
+     * name and returns it. If no packageConfig is found undefined is returned.
      * @param packageName the packageName of the packageConfig to retrieve for.
-     * @param onlyInstalled the packages to search through. true if we search the packageConfig only in the installed packages or false if all packages are searched through.
+     * @param onlyInstalled true if searching only in the installed packages or false if all packages should be searched through.
      * @returns the found packageConfig or undefined if none could be found.
      */
     getPackageConfig(packageName: string, onlyInstalled: boolean = false): PackageConfig | undefined {
@@ -191,8 +192,9 @@ export class ProjectConfig {
     }
 
     /**
-     * Adds a new packageConfig to the project. Multiple packages with the same name and version will not be added. However adding
-     * a package which has a different version will update the version.
+     * Adds a new packageConfig to the project. This method  Won't add a new package if a package with the
+     * same name already exists. Different versions are not taken into consideration. If updating the
+     * version of a packageConfig is required use #updatePackageConfig.
      *
      * @param packageConfig the packageConfig to add.
      * @returns true if the package was added successfully, false otherwise.

--- a/src/modules/project-config.ts
+++ b/src/modules/project-config.ts
@@ -181,10 +181,10 @@ export class ProjectConfig {
     }
 
     /**
-     * Searches through all / only the installed packageConfigs for the packageConfig with the specified name and returns it. If no packageConfig is found undefined is returned. 
+     * Searches through all / only the installed packageConfigs for the packageConfig with the specified name and returns it. If no packageConfig is found undefined is returned.
      * @param packageName the packageName of the packageConfig to retrieve for.
      * @param onlyInstalled the packages to search through. true if we search the packageConfig only in the installed packages or false if all packages are searched through.
-     * @returns the found packageConfig or undefined if none could be found. 
+     * @returns the found packageConfig or undefined if none could be found.
      */
     getPackageConfig(packageName: string, onlyInstalled: boolean = false): PackageConfig | undefined {
         return this.getPackages(onlyInstalled).find((config) => config.getPackageName() === packageName);

--- a/src/modules/project-config.ts
+++ b/src/modules/project-config.ts
@@ -180,8 +180,14 @@ export class ProjectConfig {
         return this._packages;
     }
 
+    /**
+     * Searches through all / only the installed packageConfigs for the packageConfig with the specified name and returns it. If no packageConfig is found undefined is returned. 
+     * @param packageName the packageName of the packageConfig to retrieve for.
+     * @param onlyInstalled the packages to search through. true if we search the packageConfig only in the installed packages or false if all packages are searched through.
+     * @returns the found packageConfig or undefined if none could be found. 
+     */
     getPackageConfig(packageName: string, onlyInstalled: boolean = false): PackageConfig | undefined {
-        return this.getPackages().find((config) => config.getPackageName() === packageName);
+        return this.getPackages(onlyInstalled).find((config) => config.getPackageName() === packageName);
     }
 
     /**
@@ -192,7 +198,7 @@ export class ProjectConfig {
      * @returns true if the package was added successfully, false otherwise.
      */
     addPackageConfig(packageConfig: PackageConfig): boolean {
-        const existingPackage = this.getPackages().find((config) => config.getPackageName() === packageConfig.getPackageName());
+        const existingPackage = this.getPackageConfig(packageConfig.getPackageName());
 
         if (!existingPackage) {
             this._packages.push(packageConfig);
@@ -208,9 +214,9 @@ export class ProjectConfig {
      * @returns true if the packageVersion was successfully updated, false otherwise.
      */
     updatePackageConfig(packageConfig: PackageConfig): boolean {
-        const existingPackage = this.getPackages().find((config) => config.getPackageName() === packageConfig.getPackageName());
+        const existingPackage = this.getPackageConfig(packageConfig.getPackageName());
 
-        if (existingPackage?.version !== packageConfig.version) {
+        if (existingPackage && existingPackage.version !== packageConfig.version) {
             existingPackage?.setPackageVersion(packageConfig.version);
             return true;
         }
@@ -246,11 +252,7 @@ export class ProjectConfig {
     getComponents(onlyUsed: boolean = true, onlyInstalled: boolean = false): ComponentContext[] {
         const componentContexts: ComponentContext[] = [];
 
-        let packageConfigs = this._packages;
-        if (onlyInstalled) {
-            packageConfigs = packageConfigs.filter((pkg) => pkg.isPackageInstalled());
-        }
-
+        let packageConfigs = this.getPackages(onlyInstalled);
         for (const packageConfig of packageConfigs) {
             const components = this.getComponentsForPackageConfig(packageConfig, onlyUsed);
             componentContexts.push(...components);

--- a/test/commands/init/init.test.ts
+++ b/test/commands/init/init.test.ts
@@ -88,7 +88,7 @@ describe('init', () => {
     })
         .stdout()
         .stub(gitModule, 'simpleGit', (stub) => stub.returns(simpleGitInstanceMock()))
-        .command(['init', '-v', '--no-hooks'])
+        .command(['init', '-v'])
         .it('should log warning when no AppManifest.json is found', (ctx) => {
             console.error(ctx.stdout);
             expect(ctx.stdout).to.contain('*** Info ***: No AppManifest found');
@@ -117,6 +117,17 @@ describe('init', () => {
         .command(['init'])
         .it('runs post-init hooks', (ctx) => {
             expect(ctx.stdout).to.contain(`... > Running post init hook for 'test-runtime-local'`);
+        });
+
+    test.do(() => {
+        mockFolders({ velocitasConfig: true, velocitasConfigLock: true, installedComponents: true });
+    })
+        .stdout()
+        .stub(gitModule, 'simpleGit', (stub) => stub.returns(simpleGitInstanceMock()))
+        .stub(exec, 'runExecSpec', (stub) => stub.returns({}))
+        .command(['init', '--no-hooks'])
+        .it('does not run post-init hooks when called with --no-hooks parameter', (ctx) => {
+            expect(ctx.stdout).to.not.contain(`... > Running post init hook`);
         });
 
     test.do(() => {

--- a/test/commands/init/init.test.ts
+++ b/test/commands/init/init.test.ts
@@ -118,4 +118,55 @@ describe('init', () => {
         .it('runs post-init hooks', (ctx) => {
             expect(ctx.stdout).to.contain(`... > Running post init hook for 'test-runtime-local'`);
         });
+
+    test.do(() => {
+        mockFolders({ velocitasConfig: true, packageIndex: true });
+    })
+        .stdout()
+        .stub(gitModule, 'simpleGit', (stub) => stub.returns(simpleGitInstanceMock()))
+        .stub(exec, 'runExecSpec', (stub) => stub.returns({}))
+        .command(['init', '--package', 'devenv-runtime'])
+        .it('adds a new entry to .velocitas.json if the package does not exist', (ctx) => {
+            expect(ctx.stdout).to.contain(`... Package 'devenv-runtime:v1.1.1' added to .velocitas.json`);
+        });
+
+    test.do(() => {
+        mockFolders({ velocitasConfig: true, packageIndex: true });
+    })
+        .stdout()
+        .stub(gitModule, 'simpleGit', (stub) => stub.returns(simpleGitInstanceMock()))
+        .stub(exec, 'runExecSpec', (stub) => stub.returns({}))
+        .command(['init', '--package', `${installedCorePackage.repo}`])
+        .it('downloads correctly the latest package if no version is specified', (ctx) => {
+            expect(ctx.stdout).to.contain(`... Downloading package: '${installedCorePackage.repo}:${installedCorePackage.version}'`);
+            expect(
+                CliFileSystem.existsSync(`${userHomeDir}/.velocitas/packages/${installedCorePackage.repo}/${installedCorePackage.version}`),
+            ).to.be.true;
+        });
+
+    test.do(() => {
+        mockFolders({ velocitasConfig: true, packageIndex: true });
+    })
+        .stdout()
+        .stub(gitModule, 'simpleGit', (stub) => stub.returns(simpleGitInstanceMock()))
+        .stub(exec, 'runExecSpec', (stub) => stub.returns({}))
+        .command(['init', '--package', `${installedCorePackage.repo}@${installedCorePackage.version}`])
+        .it('correctly downloads the defined package if a version is specified', (ctx) => {
+            expect(ctx.stdout).to.contain(`... Downloading package: '${installedCorePackage.repo}:${installedCorePackage.version}'`);
+            expect(
+                CliFileSystem.existsSync(`${userHomeDir}/.velocitas/packages/${installedCorePackage.repo}/${installedCorePackage.version}`),
+            ).to.be.true;
+        });
+
+    test.do(() => {
+        mockFolders({ velocitasConfig: true, packageIndex: true });
+    })
+        .stdout()
+        .stub(gitModule, 'simpleGit', (stub) => stub.returns(simpleGitInstanceMock()))
+        .stub(exec, 'runExecSpec', (stub) => stub.returns({}))
+        .command(['init', '--package', `${installedCorePackage.repo}@v10.5.2`])
+        .catch((err) => {
+            expect(err.message).to.contain(`Can't find matching version for v10.5.2.`);
+        })
+        .it('throws an error if an invalid version is specified', (ctx) => {});
 });

--- a/test/commands/init/init.test.ts
+++ b/test/commands/init/init.test.ts
@@ -150,7 +150,7 @@ describe('init', () => {
         .stdout()
         .stub(gitModule, 'simpleGit', (stub) => stub.returns(simpleGitInstanceMock()))
         .stub(exec, 'runExecSpec', (stub) => stub.returns({}))
-        .command(['init', '--package', `${installedCorePackage.repo}@${installedCorePackage.version}`])
+        .command(['init', '--package', `${installedCorePackage.repo}`, '--specifier', `${installedCorePackage.version}`])
         .it('correctly downloads the defined package if a version is specified', (ctx) => {
             expect(ctx.stdout).to.contain(`... Downloading package: '${installedCorePackage.repo}:${installedCorePackage.version}'`);
             expect(
@@ -164,7 +164,7 @@ describe('init', () => {
         .stdout()
         .stub(gitModule, 'simpleGit', (stub) => stub.returns(simpleGitInstanceMock()))
         .stub(exec, 'runExecSpec', (stub) => stub.returns({}))
-        .command(['init', '--package', `${installedCorePackage.repo}@v10.5.2`])
+        .command(['init', '--package', `${installedCorePackage.repo}`, '--specifier', 'v10.5.2'])
         .catch((err) => {
             expect(err.message).to.contain(`Can't find matching version for v10.5.2.`);
         })


### PR DESCRIPTION
It is now possible to initialize a standard package using `velocitas init -p devenv-runtimes`. This command will depending on if the devenv-runtimes package is defined in .velocitas.json use the version specified in .velocitas.json or use the latest version if not specified in .velocitas.json.

Using a custom version:
`velocitas init -p devenv-runtimes@v3.0.0`.

Using a custom package:
`velocitas init -p https://github.com/SoftwareDefinedVehicle/devenv-runtimes.git@v3.0.0`

If initializing a package which is not part of .velocitas.json it will automatically be added to it. If a package specifies components but no component is referenced in .velocitas.json, all components will be added automatically during initialization.