### PR TITLE
fix: correctly fetch all tags of remote repository during init

### DIFF
--- a/src/modules/package-downloader.ts
+++ b/src/modules/package-downloader.ts
@@ -34,7 +34,7 @@ export class PackageDownloader {
         const localRepoExists = await this.git.checkIsRepo(checkRepoAction);
 
         if (localRepoExists) {
-            await this.git.fetch(['--all']);
+            await this.git.fetch(['--force', '--tags', '--prune-tags']);
         } else {
             await this.git.clone(this.packageConfig.getPackageRepo(), packageDir, cloneOpts);
         }


### PR DESCRIPTION
This PR fixes a bug where the initial "_cache" folder of a cloned package is not getting updated correctly 