### PR TITLE
Fixing dependecies

### DIFF
--- a/NOTICE-3RD-PARTY-CONTENT.md
+++ b/NOTICE-3RD-PARTY-CONTENT.md
@@ -3,34 +3,486 @@
 ## JavaScript
 | Dependency | Version | License |
 |:-----------|:-------:|--------:|
+|@aashutoshrathi/word-wrap|1.2.6|MIT|
+|@ampproject/remapping|2.3.0|Apache 2.0|
+|@babel/code-frame|7.24.2|MIT|
+|@babel/compat-data|7.24.1|MIT|
+|@babel/core|7.24.3|MIT|
+|@babel/generator|7.23.0|MIT|
+|@babel/generator|7.24.1|MIT|
+|@babel/helper-compilation-targets|7.23.6|MIT|
+|@babel/helper-environment-visitor|7.22.20|MIT|
+|@babel/helper-function-name|7.23.0|MIT|
+|@babel/helper-hoist-variables|7.22.5|MIT|
+|@babel/helper-module-imports|7.24.3|MIT|
+|@babel/helper-module-transforms|7.23.3|MIT|
+|@babel/helper-simple-access|7.22.5|MIT|
+|@babel/helper-split-export-declaration|7.22.6|MIT|
+|@babel/helper-string-parser|7.24.1|MIT|
+|@babel/helper-validator-identifier|7.22.20|MIT|
+|@babel/helper-validator-option|7.23.5|MIT|
+|@babel/helpers|7.24.1|MIT|
+|@babel/highlight|7.24.2|MIT|
+|@babel/parser|7.23.0|MIT|
+|@babel/parser|7.24.1|MIT|
+|@babel/template|7.24.0|MIT|
+|@babel/traverse|7.24.1|MIT|
+|@babel/types|7.23.0|MIT|
+|@babel/types|7.24.0|MIT|
+|@cspotcode/source-map-support|0.8.1|MIT|
+|@eslint-community/eslint-utils|4.4.0|MIT|
+|@eslint-community/regexpp|4.10.0|MIT|
+|@eslint/eslintrc|2.1.4|MIT|
+|@eslint/js|8.57.0|MIT|
+|@humanwhocodes/config-array|0.11.14|Apache 2.0|
+|@humanwhocodes/module-importer|1.0.1|Apache 2.0|
+|@humanwhocodes/object-schema|2.0.2|New BSD|
+|@istanbuljs/load-nyc-config|1.1.0|ISC|
+|@istanbuljs/schema|0.1.3|MIT|
+|@jridgewell/gen-mapping|0.3.5|MIT|
+|@jridgewell/resolve-uri|3.1.2|MIT|
+|@jridgewell/set-array|1.2.1|MIT|
+|@jridgewell/sourcemap-codec|1.4.15|MIT|
+|@jridgewell/trace-mapping|0.3.25|MIT|
+|@jridgewell/trace-mapping|0.3.9|MIT|
+|@kwsites/file-exists|1.1.1|MIT|
+|@kwsites/promise-deferred|1.1.1|MIT|
+|@nodelib/fs.scandir|2.1.5|MIT|
+|@nodelib/fs.stat|2.0.5|MIT|
+|@nodelib/fs.walk|1.2.8|MIT|
 |@oclif/core|3.27.0|MIT|
 |@oclif/test|3.2.15|MIT|
+|@sinonjs/commons|2.0.0|New BSD|
+|@sinonjs/commons|3.0.1|New BSD|
+|@sinonjs/fake-timers|10.3.0|New BSD|
+|@sinonjs/fake-timers|11.2.2|New BSD|
+|@sinonjs/samsam|8.0.0|New BSD|
+|@sinonjs/text-encoding|0.7.2|(Unlicense OR Apache-2.0)|
+|@tsconfig/node10|1.0.9|MIT|
+|@tsconfig/node12|1.0.11|MIT|
+|@tsconfig/node14|1.0.3|MIT|
+|@tsconfig/node16|1.0.4|MIT|
 |@types/chai|4.3.16|MIT|
+|@types/cli-progress|3.11.5|MIT|
 |@types/fs-extra|11.0.4|MIT|
+|@types/jsonfile|6.1.4|MIT|
+|@types/lodash|4.17.4|MIT|
 |@types/mocha|10.0.6|MIT|
 |@types/node|20.14.2|MIT|
 |@types/semver|7.5.8|MIT|
-|@typescript-eslint/eslint-plugin|7.12.0|MIT|
-|@typescript-eslint/parser|7.12.0|unknown|
+|@types/sinon|17.0.3|MIT|
+|@types/sinonjs__fake-timers|8.1.5|MIT|
+|@typescript-eslint/eslint-plugin|7.15.0|MIT|
+|@typescript-eslint/parser|7.15.0|Simplified BSD|
+|@typescript-eslint/scope-manager|7.15.0|MIT|
+|@typescript-eslint/type-utils|7.15.0|MIT|
+|@typescript-eslint/types|7.15.0|MIT|
+|@typescript-eslint/typescript-estree|7.15.0|Simplified BSD|
+|@typescript-eslint/utils|7.15.0|MIT|
+|@typescript-eslint/visitor-keys|7.15.0|MIT|
+|@ungap/structured-clone|1.2.0|ISC|
 |@yao-pkg/pkg|5.11.5|MIT|
+|@yao-pkg/pkg-fetch|3.5.9|MIT|
+|acorn|8.11.3|MIT|
+|acorn-jsx|5.3.2|MIT|
+|acorn-walk|8.3.2|MIT|
+|agent-base|6.0.2|MIT|
+|aggregate-error|3.1.0|MIT|
+|ajv|6.12.6|MIT|
+|ansi-colors|4.1.1|MIT|
+|ansi-escapes|4.3.2|MIT|
+|ansi-regex|5.0.1|MIT|
+|ansi-styles|3.2.1|MIT|
+|ansi-styles|4.3.0|MIT|
+|ansicolors|0.3.2|MIT|
+|anymatch|3.1.3|ISC|
+|append-transform|2.0.0|MIT|
+|archy|1.0.0|MIT|
+|arg|4.1.3|MIT|
+|argparse|1.0.10|MIT|
+|argparse|2.0.1|Python-2.0|
+|array-differ|1.0.0|MIT|
+|array-union|1.0.2|MIT|
+|array-union|2.1.0|MIT|
+|array-uniq|1.0.3|MIT|
+|arrify|1.0.1|MIT|
+|asap|2.0.6|MIT|
+|assertion-error|1.1.0|MIT|
+|astral-regex|2.0.0|MIT|
+|async|3.2.5|MIT|
+|at-least-node|1.0.0|ISC|
+|balanced-match|1.0.2|MIT|
+|base64-js|1.5.1|MIT|
+|binary-extensions|2.3.0|MIT|
+|bl|4.1.0|MIT|
+|brace-expansion|1.1.11|MIT|
+|brace-expansion|2.0.1|MIT|
+|braces|3.0.3|MIT|
+|browser-stdout|1.3.1|ISC|
+|browserslist|4.23.0|MIT|
+|buffer|5.7.1|MIT|
+|caching-transform|4.0.0|MIT|
+|callsites|3.1.0|MIT|
+|camelcase|5.3.1|MIT|
+|camelcase|6.3.0|MIT|
+|caniuse-lite|1.0.30001599|CC-BY-4.0|
+|cardinal|2.1.1|MIT|
 |chai|4.4.1|MIT|
-|eslint|8.57.0|ISC<br/>MIT|
+|chalk|2.4.2|MIT|
+|chalk|4.1.2|MIT|
+|chardet|0.7.0|MIT|
+|check-error|1.0.3|MIT|
+|chokidar|3.5.3|MIT|
+|chownr|1.1.4|ISC|
+|clean-stack|2.2.0|MIT|
+|clean-stack|3.0.1|MIT|
+|cli-cursor|3.1.0|MIT|
+|cli-progress|3.12.0|MIT|
+|cli-spinners|2.9.2|MIT|
+|cli-width|3.0.0|ISC|
+|cliui|6.0.0|ISC|
+|cliui|7.0.4|ISC|
+|clone|1.0.4|MIT|
+|color|4.2.3|MIT|
+|color-convert|1.9.3|MIT|
+|color-convert|2.0.1|MIT|
+|color-name|1.1.3|MIT|
+|color-name|1.1.4|MIT|
+|color-string|1.9.1|MIT|
+|commondir|1.0.1|MIT|
+|concat-map|0.0.1|MIT|
+|convert-source-map|1.9.0|MIT|
+|convert-source-map|2.0.0|MIT|
+|core-util-is|1.0.3|MIT|
+|create-require|1.1.1|MIT|
+|cross-spawn|7.0.3|MIT|
+|debug|4.3.4|MIT|
+|debug|4.3.5|MIT|
+|decamelize|1.2.0|MIT|
+|decamelize|4.0.0|MIT|
+|decompress-response|6.0.0|MIT|
+|deep-eql|4.1.3|MIT|
+|deep-extend|0.6.0|MIT|
+|deep-is|0.1.4|MIT|
+|default-require-extensions|3.0.1|MIT|
+|defaults|1.0.4|MIT|
+|detect-libc|2.0.3|Apache 2.0|
+|diff|4.0.2|New BSD|
+|diff|5.0.0|New BSD|
+|diff|5.2.0|New BSD|
+|dir-glob|3.0.1|MIT|
+|doctrine|3.0.0|Apache 2.0|
+|ejs|3.1.10|Apache 2.0|
+|electron-to-chromium|1.4.713|ISC|
+|emoji-regex|8.0.0|MIT|
+|end-of-stream|1.4.4|MIT|
+|errno|0.1.8|MIT|
+|es6-error|4.1.1|MIT|
+|escalade|3.1.2|MIT|
+|escape-string-regexp|1.0.5|MIT|
+|escape-string-regexp|4.0.0|MIT|
+|eslint|8.57.0|MIT|
+|eslint-scope|7.2.2|Simplified BSD|
+|eslint-visitor-keys|3.4.3|Apache 2.0|
+|espree|9.6.1|Simplified BSD|
+|esprima|4.0.1|Simplified BSD|
+|esquery|1.5.0|New BSD|
+|esrecurse|4.3.0|Simplified BSD|
+|estraverse|5.3.0|Simplified BSD|
+|esutils|2.0.3|Simplified BSD|
+|expand-template|2.0.3|(MIT OR WTFPL)|
+|external-editor|3.1.0|MIT|
+|fancy-test|3.0.16|MIT|
+|fast-deep-equal|3.1.3|MIT|
+|fast-glob|3.3.2|MIT|
+|fast-json-stable-stringify|2.1.0|MIT|
+|fast-levenshtein|2.0.6|MIT|
+|fastq|1.17.1|ISC|
+|figures|3.2.0|MIT|
+|file-entry-cache|6.0.1|MIT|
+|filelist|1.0.4|Apache 2.0|
+|fill-range|7.1.1|MIT|
+|find-cache-dir|3.3.2|MIT|
+|find-up|4.1.0|MIT|
+|find-up|5.0.0|MIT|
+|flat|5.0.2|New BSD|
+|flat-cache|3.2.0|MIT|
+|flatted|3.3.1|ISC|
+|foreground-child|2.0.0|ISC|
+|from2|2.3.0|MIT|
+|fromentries|1.3.2|MIT|
+|fs-constants|1.0.0|MIT|
 |fs-extra|11.2.0|MIT|
+|fs-extra|9.1.0|MIT|
+|fs.realpath|1.0.0|ISC|
+|function-bind|1.1.2|MIT|
+|gensync|1.0.0-beta.2|MIT|
+|get-caller-file|2.0.5|ISC|
+|get-func-name|2.0.2|MIT|
+|get-package-type|0.1.0|MIT|
+|github-from-package|0.0.0|MIT|
+|glob|7.2.3|ISC|
+|glob|8.1.0|ISC|
+|glob-parent|5.1.2|ISC|
+|glob-parent|6.0.2|ISC|
+|globals|11.12.0|MIT|
+|globals|13.24.0|MIT|
+|globby|11.1.0|MIT|
+|graceful-fs|4.2.11|ISC|
+|graphemer|1.4.0|MIT|
+|has|1.0.4|MIT|
+|has-flag|3.0.0|MIT|
+|has-flag|4.0.0|MIT|
+|hasha|5.2.2|MIT|
+|hasown|2.0.2|MIT|
+|he|1.2.0|MIT|
+|html-escaper|2.0.2|MIT|
+|https-proxy-agent|5.0.1|MIT|
+|hyperlinker|1.0.0|MIT|
+|iconv-lite|0.4.24|MIT|
+|ieee754|1.2.1|New BSD|
+|ignore|5.3.1|MIT|
+|import-fresh|3.3.0|MIT|
+|imurmurhash|0.1.4|MIT|
+|indent-string|4.0.0|MIT|
+|inflight|1.0.6|ISC|
+|inherits|2.0.4|ISC|
+|ini|1.3.8|ISC|
 |inquirer|8.2.6|MIT|
-|mocha|10.4.0|ISC<br/>MIT|
+|interpret|1.4.0|MIT|
+|into-stream|6.0.0|MIT|
+|is-arrayish|0.3.2|MIT|
+|is-binary-path|2.1.0|MIT|
+|is-core-module|2.13.1|MIT|
+|is-core-module|2.9.0|MIT|
+|is-docker|2.2.1|MIT|
+|is-extglob|2.1.1|MIT|
+|is-fullwidth-code-point|3.0.0|MIT|
+|is-glob|4.0.3|MIT|
+|is-interactive|1.0.0|MIT|
+|is-number|7.0.0|MIT|
+|is-path-inside|3.0.3|MIT|
+|is-plain-obj|2.1.0|MIT|
+|is-stream|2.0.1|MIT|
+|is-typedarray|1.0.0|MIT|
+|is-unicode-supported|0.1.0|MIT|
+|is-windows|1.0.2|MIT|
+|is-wsl|2.2.0|MIT|
+|isarray|1.0.0|MIT|
+|isexe|2.0.0|ISC|
+|istanbul-lib-coverage|3.2.2|New BSD|
+|istanbul-lib-hook|3.0.0|New BSD|
+|istanbul-lib-instrument|4.0.3|New BSD|
+|istanbul-lib-processinfo|2.0.3|ISC|
+|istanbul-lib-report|3.0.1|New BSD|
+|istanbul-lib-source-maps|4.0.1|New BSD|
+|istanbul-reports|3.1.7|New BSD|
+|jake|10.9.1|Apache 2.0|
+|js-tokens|4.0.0|MIT|
+|js-yaml|3.14.1|MIT|
+|js-yaml|4.1.0|MIT|
+|jsesc|2.5.2|MIT|
+|json-buffer|3.0.1|MIT|
+|json-schema-traverse|0.4.1|MIT|
+|json-stable-stringify-without-jsonify|1.0.1|MIT|
+|json-stringify-safe|5.0.1|ISC|
+|json5|2.2.3|MIT|
+|jsonfile|6.1.0|MIT|
+|junk|1.0.3|MIT|
+|just-extend|6.2.0|MIT|
+|keyv|4.5.4|MIT|
+|levn|0.4.1|MIT|
+|locate-path|5.0.0|MIT|
+|locate-path|6.0.0|MIT|
+|lodash|4.17.21|MIT|
+|lodash.flattendeep|4.4.0|MIT|
+|lodash.get|4.4.2|MIT|
+|lodash.merge|4.6.2|MIT|
+|log-symbols|4.1.0|MIT|
+|loupe|2.3.7|MIT|
+|lru-cache|5.1.1|ISC|
+|make-dir|3.1.0|MIT|
+|make-dir|4.0.0|MIT|
+|make-error|1.3.6|ISC|
+|maximatch|0.1.0|MIT|
+|merge2|1.4.1|MIT|
+|micromatch|4.0.5|MIT|
+|mimic-fn|2.1.0|MIT|
+|mimic-response|3.1.0|MIT|
+|minimatch|3.1.2|ISC|
+|minimatch|5.0.1|ISC|
+|minimatch|5.1.6|ISC|
+|minimatch|9.0.4|ISC|
+|minimist|1.2.8|MIT|
+|mkdirp|0.5.6|MIT|
+|mkdirp-classic|0.5.3|MIT|
+|mocha|10.4.0|MIT|
+|mock-stdin|1.0.0|MIT|
+|ms|2.1.2|MIT|
+|ms|2.1.3|MIT|
+|multistream|4.1.0|MIT|
+|mute-stream|0.0.8|ISC|
+|nan|2.19.0|MIT|
+|napi-build-utils|1.0.2|MIT|
+|natural-compare|1.4.0|MIT|
+|natural-orderby|2.0.3|MIT|
+|nise|5.1.9|New BSD|
+|nock|13.5.4|MIT|
+|node-abi|3.56.0|MIT|
+|node-fetch|2.7.0|MIT|
+|node-preload|0.2.1|MIT|
 |node-pty|1.0.0|MIT|
-|nyc|15.1.0|ISC<br/>MIT|
-|prettier|3.3.1|Apache 2.0|
+|node-releases|2.0.14|MIT|
+|normalize-path|3.0.0|MIT|
+|nyc|15.1.0|ISC|
+|object-treeify|1.1.33|MIT|
+|once|1.4.0|ISC|
+|onetime|5.1.2|MIT|
+|optionator|0.9.3|MIT|
+|ora|5.4.1|MIT|
+|os-tmpdir|1.0.2|MIT|
+|p-is-promise|3.0.0|MIT|
+|p-limit|2.3.0|MIT|
+|p-limit|3.1.0|MIT|
+|p-locate|4.1.0|MIT|
+|p-locate|5.0.0|MIT|
+|p-map|3.0.0|MIT|
+|p-try|2.2.0|MIT|
+|package-hash|4.0.0|ISC|
+|parent-module|1.0.1|MIT|
+|password-prompt|1.1.3|BSD Zero Clause License|
+|path-exists|4.0.0|MIT|
+|path-is-absolute|1.0.1|MIT|
+|path-key|3.1.1|MIT|
+|path-parse|1.0.7|MIT|
+|path-to-regexp|6.2.1|MIT|
+|path-type|4.0.0|MIT|
+|pathval|1.1.1|MIT|
+|picocolors|1.0.0|ISC|
+|picomatch|2.3.1|MIT|
+|pify|2.3.0|MIT|
+|pkg-dir|4.2.0|MIT|
+|prebuild-install|7.1.1|MIT|
+|prelude-ls|1.2.1|MIT|
+|prettier|3.3.2|MIT|
 |prettier-plugin-organize-imports|3.2.4|MIT|
-|recursive-copy|2.0.14|ISC<br/>MIT|
+|process-nextick-args|2.0.1|MIT|
+|process-on-spawn|1.0.0|MIT|
+|progress|2.0.3|MIT|
+|promise|7.3.1|MIT|
+|propagate|2.0.1|MIT|
+|prr|1.0.1|MIT|
+|pump|3.0.0|MIT|
+|punycode|2.3.1|MIT|
+|queue-microtask|1.2.3|MIT|
+|randombytes|2.1.0|MIT|
+|rc|1.2.8|(BSD-2-Clause OR MIT OR Apache-2.0)|
+|readable-stream|2.3.8|MIT|
+|readable-stream|3.6.2|MIT|
+|readdirp|3.6.0|MIT|
+|rechoir|0.6.2|MIT|
+|recursive-copy|2.0.14|ISC|
+|redeyed|2.1.1|MIT|
+|release-zalgo|1.0.0|ISC|
+|require-directory|2.1.1|MIT|
+|require-main-filename|2.0.0|ISC|
+|resolve|1.22.8|MIT|
+|resolve-from|4.0.0|MIT|
+|resolve-from|5.0.0|MIT|
+|restore-cursor|3.1.0|MIT|
+|reusify|1.0.4|MIT|
+|rimraf|2.7.1|ISC|
+|rimraf|3.0.2|ISC|
+|run-async|2.4.1|MIT|
+|run-parallel|1.2.0|MIT|
+|rxjs|7.8.1|Apache 2.0|
+|safe-buffer|5.1.2|MIT|
+|safer-buffer|2.1.2|MIT|
+|semver|6.3.1|ISC|
 |semver|7.6.2|ISC|
+|serialize-javascript|6.0.0|New BSD|
+|set-blocking|2.0.0|ISC|
+|shebang-command|2.0.0|MIT|
+|shebang-regex|3.0.0|MIT|
+|shelljs|0.8.5|New BSD|
 |shx|0.3.4|MIT|
-|simple-git|3.24.0|unknown|
-|sinon|17.0.1|MIT<br/>New BSD|
+|signal-exit|3.0.7|ISC|
+|simple-concat|1.0.1|MIT|
+|simple-get|4.0.1|MIT|
+|simple-git|3.25.0|MIT|
+|simple-swizzle|0.2.2|MIT|
+|sinon|16.1.3|New BSD|
+|sinon|17.0.1|New BSD|
+|slash|1.0.0|MIT|
+|slash|3.0.0|MIT|
+|slice-ansi|4.0.0|MIT|
+|source-map|0.6.1|New BSD|
+|spawn-wrap|2.0.0|ISC|
+|sprintf-js|1.0.3|New BSD|
+|stdout-stderr|0.1.13|MIT|
+|stream-meter|1.0.4|MIT|
+|string-width|4.2.3|MIT|
+|string_decoder|1.1.1|MIT|
+|strip-ansi|6.0.1|MIT|
+|strip-bom|4.0.0|MIT|
+|strip-json-comments|2.0.1|MIT|
+|strip-json-comments|3.1.1|MIT|
+|supports-color|5.5.0|MIT|
+|supports-color|7.2.0|MIT|
+|supports-color|8.1.1|MIT|
+|supports-hyperlinks|2.3.0|MIT|
+|supports-preserve-symlinks-flag|1.0.0|MIT|
+|tar-fs|2.1.1|MIT|
+|tar-stream|2.2.0|MIT|
+|test-exclude|6.0.0|ISC|
+|text-table|0.2.0|MIT|
+|through|2.3.8|MIT|
+|tmp|0.0.33|MIT|
+|to-fast-properties|2.0.0|MIT|
+|to-regex-range|5.0.1|MIT|
+|tr46|0.0.3|MIT|
+|ts-api-utils|1.3.0|MIT|
 |ts-node|10.9.2|MIT|
+|tslib|2.6.2|BSD Zero Clause License|
+|tunnel-agent|0.6.0|Apache 2.0|
+|type-check|0.4.0|MIT|
+|type-detect|4.0.8|MIT|
+|type-fest|0.20.2|(MIT OR CC0-1.0)|
+|type-fest|0.21.3|(MIT OR CC0-1.0)|
+|type-fest|0.8.1|(MIT OR CC0-1.0)|
+|typedarray-to-buffer|3.1.5|MIT|
 |typescript|5.4.5|Apache 2.0|
+|undici-types|5.26.5|MIT|
+|universalify|2.0.1|MIT|
+|update-browserslist-db|1.0.13|MIT|
+|uri-js|4.4.1|Simplified BSD|
+|util-deprecate|1.0.2|MIT|
+|uuid|8.3.2|MIT|
+|v8-compile-cache-lib|3.0.1|MIT|
 |velocitas-cli|0.0.0|Apache 2.0|
-|yaml|2.4.3|ISC|
+|wcwidth|1.0.1|MIT|
+|webidl-conversions|3.0.1|Simplified BSD|
+|whatwg-url|5.0.0|MIT|
+|which|2.0.2|ISC|
+|which-module|2.0.1|ISC|
+|widest-line|3.1.0|MIT|
+|wordwrap|1.0.0|MIT|
+|workerpool|6.2.1|Apache 2.0|
+|wrap-ansi|6.2.0|MIT|
+|wrap-ansi|7.0.0|MIT|
+|wrappy|1.0.2|ISC|
+|write-file-atomic|3.0.3|ISC|
+|y18n|4.0.3|ISC|
+|y18n|5.0.8|ISC|
+|yallist|3.1.1|ISC|
+|yaml|2.4.5|ISC|
+|yargs|15.4.1|MIT|
+|yargs|16.2.0|MIT|
+|yargs-parser|18.1.3|ISC|
+|yargs-parser|20.2.4|ISC|
+|yargs-unparser|2.0.0|MIT|
+|yn|3.1.1|MIT|
+|yocto-queue|0.1.0|MIT|
 ## Workflows
 | Dependency | Version | License |
 |:-----------|:-------:|--------:|

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "node-pty": "1.0.0",
         "recursive-copy": "2.0.14",
         "semver": "7.6.2",
-        "simple-git": "3.24.0"
+        "simple-git": "3.25.0"
       },
       "bin": {
         "velocitas": "bin/run"
@@ -27,20 +27,20 @@
         "@types/mocha": "10.0.6",
         "@types/node": "20.14.2",
         "@types/semver": "^7.5.8",
-        "@typescript-eslint/eslint-plugin": "7.12.0",
-        "@typescript-eslint/parser": "7.12.0",
+        "@typescript-eslint/eslint-plugin": "7.15.0",
+        "@typescript-eslint/parser": "7.15.0",
         "@yao-pkg/pkg": "5.11.5",
         "chai": "4.4.1",
         "eslint": "8.57.0",
         "mocha": "10.4.0",
         "nyc": "15.1.0",
-        "prettier": "3.3.1",
+        "prettier": "3.3.2",
         "prettier-plugin-organize-imports": "3.2.4",
         "shx": "0.3.4",
         "sinon": "^17.0.1",
         "ts-node": "10.9.2",
         "typescript": "5.4.5",
-        "yaml": "2.4.3"
+        "yaml": "2.4.5"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -1160,16 +1160,17 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.12.0.tgz",
-      "integrity": "sha512-7F91fcbuDf/d3S8o21+r3ZncGIke/+eWk0EpO21LXhDfLahriZF9CGj4fbAetEjlaBdjdSm9a6VeXbpbT6Z40Q==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.15.0.tgz",
+      "integrity": "sha512-uiNHpyjZtFrLwLDpHnzaDlP3Tt6sGMqTCiqmxaN4n4RP0EfYZDODJyddiFDF44Hjwxr5xAcaYxVKm9QKQFJFLA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "7.12.0",
-        "@typescript-eslint/type-utils": "7.12.0",
-        "@typescript-eslint/utils": "7.12.0",
-        "@typescript-eslint/visitor-keys": "7.12.0",
+        "@typescript-eslint/scope-manager": "7.15.0",
+        "@typescript-eslint/type-utils": "7.15.0",
+        "@typescript-eslint/utils": "7.15.0",
+        "@typescript-eslint/visitor-keys": "7.15.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -1193,15 +1194,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.12.0.tgz",
-      "integrity": "sha512-dm/J2UDY3oV3TKius2OUZIFHsomQmpHtsV0FTh1WO8EKgHLQ1QCADUqscPgTpU+ih1e21FQSRjXckHn3txn6kQ==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.15.0.tgz",
+      "integrity": "sha512-k9fYuQNnypLFcqORNClRykkGOMOj+pV6V91R4GO/l1FDGwpqmSwoOQrOHo3cGaH63e+D3ZiCAOsuS/D2c99j/A==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "7.12.0",
-        "@typescript-eslint/types": "7.12.0",
-        "@typescript-eslint/typescript-estree": "7.12.0",
-        "@typescript-eslint/visitor-keys": "7.12.0",
+        "@typescript-eslint/scope-manager": "7.15.0",
+        "@typescript-eslint/types": "7.15.0",
+        "@typescript-eslint/typescript-estree": "7.15.0",
+        "@typescript-eslint/visitor-keys": "7.15.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1221,13 +1223,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.12.0.tgz",
-      "integrity": "sha512-itF1pTnN6F3unPak+kutH9raIkL3lhH1YRPGgt7QQOh43DQKVJXmWkpb+vpc/TiDHs6RSd9CTbDsc/Y+Ygq7kg==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.15.0.tgz",
+      "integrity": "sha512-Q/1yrF/XbxOTvttNVPihxh1b9fxamjEoz2Os/Pe38OHwxC24CyCqXxGTOdpb4lt6HYtqw9HetA/Rf6gDGaMPlw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "7.12.0",
-        "@typescript-eslint/visitor-keys": "7.12.0"
+        "@typescript-eslint/types": "7.15.0",
+        "@typescript-eslint/visitor-keys": "7.15.0"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -1238,13 +1241,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.12.0.tgz",
-      "integrity": "sha512-lib96tyRtMhLxwauDWUp/uW3FMhLA6D0rJ8T7HmH7x23Gk1Gwwu8UZ94NMXBvOELn6flSPiBrCKlehkiXyaqwA==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.15.0.tgz",
+      "integrity": "sha512-SkgriaeV6PDvpA6253PDVep0qCqgbO1IOBiycjnXsszNTVQe5flN5wR5jiczoEoDEnAqYFSFFc9al9BSGVltkg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "7.12.0",
-        "@typescript-eslint/utils": "7.12.0",
+        "@typescript-eslint/typescript-estree": "7.15.0",
+        "@typescript-eslint/utils": "7.15.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -1265,10 +1269,11 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.12.0.tgz",
-      "integrity": "sha512-o+0Te6eWp2ppKY3mLCU+YA9pVJxhUJE15FV7kxuD9jgwIAa+w/ycGJBMrYDTpVGUM/tgpa9SeMOugSabWFq7bg==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.15.0.tgz",
+      "integrity": "sha512-aV1+B1+ySXbQH0pLK0rx66I3IkiZNidYobyfn0WFsdGhSXw+P3YOqeTq5GED458SfB24tg+ux3S+9g118hjlTw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
       },
@@ -1278,13 +1283,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.12.0.tgz",
-      "integrity": "sha512-5bwqLsWBULv1h6pn7cMW5dXX/Y2amRqLaKqsASVwbBHMZSnHqE/HN4vT4fE0aFsiwxYvr98kqOWh1a8ZKXalCQ==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.15.0.tgz",
+      "integrity": "sha512-gjyB/rHAopL/XxfmYThQbXbzRMGhZzGw6KpcMbfe8Q3nNQKStpxnUKeXb0KiN/fFDR42Z43szs6rY7eHk0zdGQ==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/types": "7.12.0",
-        "@typescript-eslint/visitor-keys": "7.12.0",
+        "@typescript-eslint/types": "7.15.0",
+        "@typescript-eslint/visitor-keys": "7.15.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -1306,15 +1312,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.12.0.tgz",
-      "integrity": "sha512-Y6hhwxwDx41HNpjuYswYp6gDbkiZ8Hin9Bf5aJQn1bpTs3afYY4GX+MPYxma8jtoIV2GRwTM/UJm/2uGCVv+DQ==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.15.0.tgz",
+      "integrity": "sha512-hfDMDqaqOqsUVGiEPSMLR/AjTSCsmJwjpKkYQRo1FNbmW4tBwBspYDwO9eh7sKSTwMQgBw9/T4DHudPaqshRWA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "7.12.0",
-        "@typescript-eslint/types": "7.12.0",
-        "@typescript-eslint/typescript-estree": "7.12.0"
+        "@typescript-eslint/scope-manager": "7.15.0",
+        "@typescript-eslint/types": "7.15.0",
+        "@typescript-eslint/typescript-estree": "7.15.0"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -1328,12 +1335,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.12.0.tgz",
-      "integrity": "sha512-uZk7DevrQLL3vSnfFl5bj4sL75qC9D6EdjemIdbtkuUmIheWpuiiylSY01JxJE7+zGrOWDZrp1WxOuDntvKrHQ==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.15.0.tgz",
+      "integrity": "sha512-Hqgy/ETgpt2L5xueA/zHHIl4fJI2O4XUE9l4+OIfbJIRSnTJb/QscncdqqZzofQegIJugRIF57OJea1khw2SDw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "7.12.0",
+        "@typescript-eslint/types": "7.15.0",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
@@ -1735,11 +1743,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -2726,9 +2735,10 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -3355,6 +3365,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -4749,10 +4760,11 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.1.tgz",
-      "integrity": "sha512-7CAwy5dRsxs8PHXT3twixW9/OEll8MLE0VRPCJyl7CkS6VHGPSlsVaWTiASPTyGyYRyApxlaWTzwUxVNrhcwDg==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.2.tgz",
+      "integrity": "sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -5386,17 +5398,35 @@
       }
     },
     "node_modules/simple-git": {
-      "version": "3.24.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.24.0.tgz",
-      "integrity": "sha512-QqAKee9Twv+3k8IFOFfPB2hnk6as6Y6ACUpwCtQvRYBAes23Wv3SZlHVobAzqcE8gfsisCvPw3HGW3HYM+VYYw==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.25.0.tgz",
+      "integrity": "sha512-KIY5sBnzc4yEcJXW7Tdv4viEz8KyG+nU0hay+DWZasvdFOYKeUZ6Xc25LUHHjw0tinPT7O1eY6pzX7pRT1K8rw==",
+      "license": "MIT",
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.3.4"
+        "debug": "^4.3.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/steveukx/git-js?sponsor=1"
+      }
+    },
+    "node_modules/simple-git/node_modules/debug": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/simple-swizzle": {
@@ -5758,6 +5788,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -6093,10 +6124,11 @@
       "dev": true
     },
     "node_modules/yaml": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.3.tgz",
-      "integrity": "sha512-sntgmxj8o7DE7g/Qi60cqpLBA3HG3STcDA0kO+WfB05jEKhZMbY7umNm2rBpQvsmZ16/lPXCJGW2672dgOUkrg==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.5.tgz",
+      "integrity": "sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "node-pty": "1.0.0",
     "recursive-copy": "2.0.14",
     "semver": "7.6.2",
-    "simple-git": "3.24.0"
+    "simple-git": "3.25.0"
   },
   "devDependencies": {
     "@oclif/test": "3.2.15",
@@ -32,20 +32,20 @@
     "@types/mocha": "10.0.6",
     "@types/node": "20.14.2",
     "@types/semver": "^7.5.8",
-    "@typescript-eslint/eslint-plugin": "7.12.0",
-    "@typescript-eslint/parser": "7.12.0",
+    "@typescript-eslint/eslint-plugin": "7.15.0",
+    "@typescript-eslint/parser": "7.15.0",
     "@yao-pkg/pkg": "5.11.5",
     "chai": "4.4.1",
     "eslint": "8.57.0",
     "mocha": "10.4.0",
     "nyc": "15.1.0",
-    "prettier": "3.3.1",
+    "prettier": "3.3.2",
     "prettier-plugin-organize-imports": "3.2.4",
     "shx": "0.3.4",
     "sinon": "^17.0.1",
     "ts-node": "10.9.2",
     "typescript": "5.4.5",
-    "yaml": "2.4.3"
+    "yaml": "2.4.5"
   },
   "oclif": {
     "bin": "velocitas",


### PR DESCRIPTION
Dependabot cannot fix them as NOTICE file needs manual update.
Based on PRs #280, #281, #283, #288, #289 and

```
sudo npm install
sudo npm audit fix
```

Note the big change in the NOTICE file - actually the license check fails on main, see https://github.com/eclipse-velocitas/cli/actions/workflows/check-licenses.yml
