### PR TITLE
Fix checkout for branches

### DIFF
--- a/src/modules/package-downloader.ts
+++ b/src/modules/package-downloader.ts
@@ -45,7 +45,7 @@ export class PackageDownloader {
     }
 
     private async _checkoutVersion(version: string): Promise<void> {
-        const branchOrTag = version.startsWith(BRANCH_PREFIX) ? version.substring(BRANCH_PREFIX.length) : version;
+        const branchOrTag = version.startsWith(BRANCH_PREFIX) ? `origin/${version.substring(BRANCH_PREFIX.length)}` : version;
         await this.git.checkout(branchOrTag);
     }
 


### PR DESCRIPTION
This fixes a problem when using a `.velocitas.json` like

```
    "packages": {
        "devenv-runtimes": "v4.0.5",
        "devenv-github-workflows": "v6.1.1",
        "devenv-github-templates": "v1.0.5",
        "devenv-devcontainer-setup": "v2.4.8",
        "https://github.com/erikbosch/my-fancy-repo.git": "@main"
    },
```

I.e. using a branch reference for a repo. As of today, if there are new commits on the given repo/branch, they will not have effect in velocitas, not even if you do `velocitas init -f`. If using `-f` the tool do a fetch but then checks out `main` which is a local branch created on original clone/checkout. With this change it will instead checkout `origin/main` which is the updated remote branch.

(If you do `velocitas init` (without `-f`) there will be no fetch, but that is according to design I assume, you will only get updates to tags/branches if using `-f`)
