### PR TITLE
Execute Python-based components in Python venv

### DIFF
--- a/NOTICE-3RD-PARTY-CONTENT.md
+++ b/NOTICE-3RD-PARTY-CONTENT.md
@@ -1,4 +1,4 @@
-# Licenses Notice# Licenses Notice
+# Licenses Notice
 *Note*: This file is auto-generated. Do not modify it manually.
 ## JavaScript
 | Dependency | Version | License |

--- a/NOTICE-3RD-PARTY-CONTENT.md
+++ b/NOTICE-3RD-PARTY-CONTENT.md
@@ -481,13 +481,13 @@
 ## Workflows
 | Dependency | Version | License |
 |:-----------|:-------:|--------:|
-|actions/checkout|v4|MIT License|
-|actions/download-artifact|v4|MIT License|
-|actions/setup-node|v4|MIT License|
-|actions/upload-artifact|v4|MIT License|
-|docker/setup-qemu-action|v3|Apache License 2.0|
-|irongut/CodeCoverageSummary|v1.3.0|MIT License|
-|ncipollo/release-action|v1|MIT License|
-|pre-commit/action|v3.0.1|MIT License|
-|TriPSs/conventional-changelog-action|v5|MIT License|
-|uraimo/run-on-arch-action|v2|BSD 3-Clause "New" or "Revised" License|
+|actions/checkout|v4||
+|actions/download-artifact|v4||
+|actions/setup-node|v4||
+|actions/upload-artifact|v4||
+|docker/setup-qemu-action|v3||
+|irongut/CodeCoverageSummary|v1.3.0||
+|ncipollo/release-action|v1||
+|pre-commit/action|v3.0.1||
+|TriPSs/conventional-changelog-action|v5||
+|uraimo/run-on-arch-action|v2||

--- a/NOTICE-3RD-PARTY-CONTENT.md
+++ b/NOTICE-3RD-PARTY-CONTENT.md
@@ -1,4 +1,4 @@
-# Licenses Notice
+# Licenses Notice# Licenses Notice
 *Note*: This file is auto-generated. Do not modify it manually.
 ## JavaScript
 | Dependency | Version | License |
@@ -481,13 +481,13 @@
 ## Workflows
 | Dependency | Version | License |
 |:-----------|:-------:|--------:|
-|actions/checkout|v4||
-|actions/download-artifact|v4||
-|actions/setup-node|v4||
-|actions/upload-artifact|v4||
-|docker/setup-qemu-action|v3||
-|irongut/CodeCoverageSummary|v1.3.0||
-|ncipollo/release-action|v1||
-|pre-commit/action|v3.0.1||
-|TriPSs/conventional-changelog-action|v5||
-|uraimo/run-on-arch-action|v2||
+|actions/checkout|v4|MIT License|
+|actions/download-artifact|v4|MIT License|
+|actions/setup-node|v4|MIT License|
+|actions/upload-artifact|v4|MIT License|
+|docker/setup-qemu-action|v3|Apache License 2.0|
+|irongut/CodeCoverageSummary|v1.3.0|MIT License|
+|ncipollo/release-action|v1|MIT License|
+|pre-commit/action|v3.0.1|MIT License|
+|TriPSs/conventional-changelog-action|v5|MIT License|
+|uraimo/run-on-arch-action|v2|BSD 3-Clause "New" or "Revised" License|

--- a/README.md
+++ b/README.md
@@ -285,6 +285,9 @@ EXAMPLES
 
 _See code: [src/commands/exec/index.ts](src/commands/exec/index.ts)_
 
+**Hint:** The execution of Python-based scripts is done in seperated Python venvs per COMPONENT;
+see section [ProgramSpec in docs/features/PACKAGES.md](docs/features/PACKAGES.md#programspec).
+
 ## `velocitas init`
 
 Initializes Velocitas Vehicle App

--- a/docs/features/PACKAGES.md
+++ b/docs/features/PACKAGES.md
@@ -122,11 +122,17 @@ Specifies a program exposed by a component and its default parameters when invok
 }
 ```
 
-**Note:** If the executable is `python[3]` (or `pip[3]`) the execution of the Python program is automatically done within a [Python venv (virtual environment)](https://docs.python.org/3/tutorial/venv.html) specific to the component. I.e. the CLI will setup a separate venv per component. All Python programs of that component will be executed within that "component's" virtual environment. With this separation of execution environments it is possible to handle different versions of depenencies per component without generating version conflicts.
+**Note:** If the `executable` is `python[3]` (or `pip[3]`) the execution of the Python program is automatically done
+within a [Python venv (virtual environment)](https://docs.python.org/3/tutorial/venv.html) specific to the component.
+I.e. the CLI will setup a separate venv per component. All Python programs of that component will be executed within
+that "component's" virtual environment. With this separation of execution environments it is possible to handle
+different versions of depenencies per component without generating version conflicts.
 
-This automatism can be avoided by specifying the Python interpreter explicitly, e.g. by using an absolute path like `/usr/bin/python`.
+This automatism can be avoided by specifying the Python interpreter explicitly, e.g. by using an absolute path like
+`/usr/bin/python`.
 
-Other Python processes spawned from a Python-based program will **not** be automatically executed in a Python venv. (Because the dependencies of that scripts probably will differ from those of the calling component.)
+Other Python processes spawned from a Python-based program will **not** be automatically executed in a Python venv.
+(Because the dependencies of that scripts will probably differ from those of the calling program's component.)
 
 ### `id` - string
 

--- a/docs/features/PACKAGES.md
+++ b/docs/features/PACKAGES.md
@@ -122,6 +122,12 @@ Specifies a program exposed by a component and its default parameters when invok
 }
 ```
 
+**Note:** If the executable is `python[3]` (or `pip[3]`) the execution of the Python program is automatically done within a [Python venv (virtual environment)](https://docs.python.org/3/tutorial/venv.html) specific to the component. I.e. the CLI will setup a separate venv per component. All Python programs of that component will be executed within that "component's" virtual environment. With this separation of execution environments it is possible to handle different versions of depenencies per component without generating version conflicts.
+
+This automatism can be avoided by specifying the Python interpreter explicitly, e.g. by using an absolute path like `/usr/bin/python`.
+
+Other Python processes spawned from a Python-based program will **not** be automatically executed in a Python venv. (Because the dependencies of that scripts probably will differ from those of the calling component.)
+
 ### `id` - string
 
 Unique ID within this component to identify the program.

--- a/docs/features/PACKAGES.md
+++ b/docs/features/PACKAGES.md
@@ -125,7 +125,7 @@ Specifies a program exposed by a component and its default parameters when invok
 **Note:** If the `executable` is `python[3]` (or `pip[3]`) the execution of the Python program is automatically done
 within a [Python venv (virtual environment)](https://docs.python.org/3/tutorial/venv.html) specific to the component.
 I.e. the CLI will setup a separate venv per component. All Python programs of that component will be executed within
-that "component's" virtual environment. With this separation of execution environments it is possible to handle
+that component-specific virtual environment. With this separation of execution environments it is possible to handle
 different versions of depenencies per component without generating version conflicts.
 
 This automatism can be avoided by specifying the Python interpreter explicitly, e.g. by using an absolute path like
@@ -133,6 +133,10 @@ This automatism can be avoided by specifying the Python interpreter explicitly, 
 
 Other Python processes spawned from a Python-based program will **not** be automatically executed in a Python venv.
 (Because the dependencies of that scripts will probably differ from those of the calling program's component.)
+
+The venv of each component is created within the project cache directory in the folder `pyvenv`. For example the
+component `Foo`s venv would be located in `/home/vscode/.velocitas/projects/<hash>/pyvenv/foo/`. This also contains
+the installed dependencies of that component.
 
 ### `id` - string
 

--- a/src/modules/exec.ts
+++ b/src/modules/exec.ts
@@ -151,7 +151,7 @@ async function createPythonVenv(
     cwd: string,
     loggingOptions: { writeStdout?: boolean; verbose?: boolean },
 ) {
-    let venvDir = `${ProjectCache.getCacheDir()}/pyvenv/${componentId}`;
+    const venvDir = `${ProjectCache.getCacheDir()}/pyvenv/${componentId}`;
     let venvCreateCmd = command;
     if (command === 'pip') {
         venvCreateCmd = 'python';

--- a/src/modules/exec.ts
+++ b/src/modules/exec.ts
@@ -154,6 +154,10 @@ async function ensureVenvIfPython(
             venvCreateCmd = 'python3';
         }
 
+        if (loggingOptions.writeStdout === undefined) {
+            loggingOptions.writeStdout = true;
+        }
+
         const result = await awaitSpawn(venvCreateCmd, ['-m', 'venv', venvDir], cwd, envVars, loggingOptions.writeStdout);
         if (result && result.exitCode !== 0) {
             throw new ExecExitError(`Failed creating Python venv: ${result.exitCode}`, result.exitCode);


### PR DESCRIPTION
Execute Python scripts of components in separate Python venv per component.
This allows handling of different dependency versions per component.