### PR TITLE
Improve error handling

### DIFF
--- a/src/modules/projectConfig/projectConfigFileReader.ts
+++ b/src/modules/projectConfig/projectConfigFileReader.ts
@@ -52,12 +52,14 @@ export class MultiFormatConfigReader implements IProjectConfigReader {
                     break;
                 }
             } catch (error: any) {
-                console.warn(`Warning: ${path} not in expected format: ${error.message}, falling back to legacy format reading.`);
+                // This could be format error, but it could also be that repo/tag-settings are faulty, repo cannot be reached and
+                // similar, for example that "velocitas init" did not succeed!
+                console.warn(`Error reported by config reader ${reader.constructor.name}: ${error.message}`);
             }
         }
 
         if (config === null) {
-            throw new Error(`Unable to read ${path}: unknown format!`);
+            throw new Error(`Unable to successfully read and interpret ${path}!`);
         }
 
         return config;

--- a/src/modules/projectConfig/projectConfigLock.ts
+++ b/src/modules/projectConfig/projectConfigLock.ts
@@ -32,7 +32,7 @@ export class ProjectConfigLock implements ProjectConfigLockAttributes {
     public findVersion(packageName: string): string {
         const packageVersion = this.packages.get(packageName);
         if (!packageVersion) {
-            throw new Error(`Package '${packageName}' not found in lock file.`);
+            throw new Error(`Package '${packageName}' not found in lock file. Have you performed "velocitas init"?`);
         }
         return packageVersion;
     }

--- a/test/commands/init/init.test.ts
+++ b/test/commands/init/init.test.ts
@@ -92,21 +92,37 @@ describe('init', () => {
         });
 
     test.do(() => {
+        // Make sure that one package lack manifest.json
         mockFolders({ velocitasConfig: true, packageIndex: true, installedComponents: true });
+        CliFileSystem.removeSync(
+            `${userHomeDir}/.velocitas/packages/${runtimePackageInfoMock.repo}/${runtimePackageInfoMock.resolvedVersion}/manifest.json`,
+        );
+        CliFileSystem.promisesMkdir(
+            `${userHomeDir}/.velocitas/packages/${runtimePackageInfoMock.repo}/${runtimePackageInfoMock.resolvedVersion}`,
+        );
     })
         .stdout()
-        .stub(gitModule, 'simpleGit', (stub) => stub.returns(simpleGitInstanceMock(undefined, false)))
+        .stub(gitModule, 'simpleGit', (stub) => stub.returns(simpleGitInstanceMock(undefined, true, true)))
         .stub(exec, 'runExecSpec', (stub) => stub.returns({}))
         .command(['init', '-v'])
-        .it('downloads corrupted packages again', (ctx) => {
+        .it('refreshing corrupted package', (ctx) => {
             expect(ctx.stdout).to.contain('Initializing Velocitas packages ...');
+
             expect(ctx.stdout).to.contain(
-                `... Corrupted .git directory found for: '${corePackageInfoMock.repo}:${corePackageInfoMock.resolvedVersion}'`,
+                `... Corrupted .git directory found for: '${runtimePackageInfoMock.repo}:${runtimePackageInfoMock.resolvedVersion}'`,
+                `Some error ${ctx.stdout}`,
             );
-            expect(ctx.stdout).to.contain(`... Downloading package: '${corePackageInfoMock.repo}:${corePackageInfoMock.resolvedVersion}'`);
+            expect(ctx.stdout).to.contain(
+                `... Downloading package: '${runtimePackageInfoMock.repo}:${runtimePackageInfoMock.resolvedVersion}'`,
+            );
             expect(
                 CliFileSystem.existsSync(
-                    `${userHomeDir}/.velocitas/packages/${corePackageInfoMock.repo}/${corePackageInfoMock.resolvedVersion}`,
+                    `${userHomeDir}/.velocitas/packages/${runtimePackageInfoMock.repo}/${runtimePackageInfoMock.resolvedVersion}`,
+                ),
+            );
+            expect(
+                CliFileSystem.existsSync(
+                    `${userHomeDir}/.velocitas/packages/${runtimePackageInfoMock.repo}/${runtimePackageInfoMock.resolvedVersion}/manifest.json`,
                 ),
             ).to.be.true;
         });

--- a/test/helpers/simpleGit.ts
+++ b/test/helpers/simpleGit.ts
@@ -13,9 +13,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { CliFileSystem } from '../../src/utils/fs-bridge';
-import { corePackageManifestMock, runtimePackageManifestMock, setupPackageManifestMock } from '../utils/mockConfig';
+import { corePackageManifestMock, runtimePackageInfoMock, runtimePackageManifestMock, setupPackageManifestMock } from '../utils/mockConfig';
+import { userHomeDir } from '../utils/mockfs';
 
-export const simpleGitInstanceMock = (mockedNewVersionTag?: string, checkRepo: boolean = true) => {
+export const simpleGitInstanceMock = (mockedNewVersionTag?: string, checkRepo: boolean = true, resetRuntime: boolean = false) => {
     return {
         clone: async (repoPath: string, localPath: string, options?: any) => {
             await CliFileSystem.promisesMkdir(localPath);
@@ -33,6 +34,16 @@ export const simpleGitInstanceMock = (mockedNewVersionTag?: string, checkRepo: b
             return checkRepo;
         },
         fetch: () => {},
+        reset: async () => {
+            // This is to recover in test case "refreshing corrupted package"
+            // In the case we have "corrupted" the repo by removing the manifest
+            if (resetRuntime) {
+                await CliFileSystem.promisesWriteFile(
+                    `${userHomeDir}/.velocitas/packages/${runtimePackageInfoMock.repo}/${runtimePackageInfoMock.resolvedVersion}/manifest.json`,
+                    JSON.stringify(runtimePackageManifestMock),
+                );
+            }
+        },
         checkout: () => {
             // Function implementation
         },

--- a/test/unit/projectConfigIO.test.ts
+++ b/test/unit/projectConfigIO.test.ts
@@ -221,7 +221,7 @@ describe('projectConfigIO - module', () => {
         it('should handle errors when parsing .velocitas.json file', () => {
             const readFileStub = sinon.stub(CliFileSystem, 'readFileSync').throws();
             const projectConfigFileReader = () => ProjectConfigIO.read('', configFilePath, true);
-            expect(projectConfigFileReader).to.throw(`Unable to read ${configFilePath}: unknown format!`);
+            expect(projectConfigFileReader).to.throw(`Unable to successfully read and interpret ${configFilePath}`);
             readFileStub.restore();
         });
 


### PR DESCRIPTION
This intends to give better error handling for velocitas init and velocitas sync.

Background is that you sometimes got misleading errors, like:

- If the repo specified in velocitas.json did not exist it as reported as "format error"
- For some git errors "raw" simple-git expections were shown, now I try to give more context specific velocitas errors. If you want the simple-git ones you need to use verbose mode
- I try to do some more tests after clone. Hopefully to not just silently ignore that we failed to clone due to rate limit.

Below is an example of how it could look like after this PR when trying to use a non-existing repo

![image](https://github.com/user-attachments/assets/44fb44dc-6e52-4f22-8cf7-23120cba6817)

I did some updates to testing to make things running, but in general the mocking is quite messy, especially if you want to trigger specific error situations.
