### PR TITLE
[Fix] Move Python venv folder location to ~/.velocitas/packages/

### DIFF
--- a/docs/features/PACKAGES.md
+++ b/docs/features/PACKAGES.md
@@ -135,7 +135,7 @@ Other Python processes spawned from a Python-based program will **not** be autom
 (Because the dependencies of that scripts will probably differ from those of the calling program's component.)
 
 The venv of each component is created within the project cache directory in the folder `pyvenv`. For example the
-component `Foo`s venv would be located in `/home/vscode/.velocitas/projects/<hash>/pyvenv/foo/`. This also contains
+component `Foo`s venv would be located in `/home/vscode/.velocitas/packages/.pyvenvs/foo/`. This also contains
 the installed dependencies of that component.
 
 ### `id` - string

--- a/src/modules/exec.ts
+++ b/src/modules/exec.ts
@@ -16,6 +16,7 @@ import { IPty, spawn } from 'node-pty';
 import { exec } from 'node:child_process';
 import { resolve } from 'node:path';
 import { ExecSpec, ProgramSpec } from './component';
+import { getPackageFolderPath } from './package';
 import { ProjectCache } from './project-cache';
 import { ProjectConfig } from './projectConfig/projectConfig';
 import { stdOutParser } from './stdout-parser';
@@ -151,7 +152,7 @@ async function createPythonVenv(
     cwd: string,
     loggingOptions: { writeStdout?: boolean; verbose?: boolean },
 ) {
-    const venvDir = `${ProjectCache.getCacheDir()}/pyvenv/${componentId}`;
+    const venvDir = `${getPackageFolderPath()}/.pyvenvs/${componentId}`;
     let venvCreateCmd = command;
     if (command === 'pip') {
         venvCreateCmd = 'python';


### PR DESCRIPTION
Since CLI v0.13.0 the Python dependencies of each CLI component (which is using Python) is maintained in the Velocitas cache under `~/.velocitas/projects/<md5-hash>/pyvenv/`.

The problem arising with that path is that the md5-hash depends on the name of the workspace folder. In case of the offline container this can lead to the following issue: 
During creation with the Lattice app template the folder is `/workspaces/vehicle-app-cpp-template-lattice`. If the receiver of the offline container puts it into a folder named differently than `<...>/vehicle-app-cpp-template-lattice`, e.g. `<...>/my_app` then the folder inside the running devcontainer is `/workspaces/my_app/` resulting in another hash calculated for the Velocitas cache. All the Python venvs initialized during the offline container creation are then located in the wrong cache folder. A re-initialization of the venvs would require an online connection, which is not supposed to be available with the offline container.

This fix moves the venv folders to a different location being independent on the workspace folder name:
The new path is `~/.velocitas/packages/.pyenvs/`.
