### PR TITLE
Fix *Maintained by Velocitas* insertion pattern for xml-based files

### DIFF
--- a/src/modules/setup.ts
+++ b/src/modules/setup.ts
@@ -51,7 +51,7 @@ const filetypesForCommentInsertion: CommentInsertionHint[] = [
     {
         ext: ['.html', '.htm', '.xml', '.tpl'],
         commentTemplate: '<!-- %COMMENT% -->',
-        insertAfterLineMatcher: new RegExp(`\\<\\?xml\\s.*?\\s\\?\\>`),
+        insertAfterLineMatcher: new RegExp(`\\<\\?xml\\s.*?\\?\\>`),
     },
     {
         ext: '.json',


### PR DESCRIPTION
The current pattern to detect the xml prologue expects a whitespace before the trailing `?>`, i.e. it properly detects prologues like
```
<?xml version="1.0" ?>
```
but not ones without:
```
<?xml version="1.0"?>
```
But this is also a common pattern. This is fixed with this PR.